### PR TITLE
Initial auto-generation of Fortran source documentation

### DIFF
--- a/docs/src_docs/addrhocr.f90.md
+++ b/docs/src_docs/addrhocr.f90.md
@@ -1,0 +1,34 @@
+# addrhocr.f90
+
+## Overview
+
+  Adds the core density to the muffin-tin and interstitial densities. A
+  uniform background density is added in the interstitial region to take into
+  account leakage of core charge from the muffin-tin spheres.
+
+  Created April 2003 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE addrhocr
+
+## Important Variables/Constants
+
+- `Integer :: is, ia, ias, ir` (No comment)
+- `Real (8) :: fr (nrmtmax), gr (nrmtmax), cf (3, nrmtmax)` (No comment)
+- `Real (8) :: t1, sum1, sum2` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- modmain
+
+**Calls:**
+- fderiv

--- a/docs/src_docs/allatoms.f90.md
+++ b/docs/src_docs/allatoms.f90.md
@@ -1,0 +1,63 @@
+# allatoms.f90
+
+## Overview
+
+  Solves the Kohn-Sham-Dirac equations for each atom type in the solid and
+  finds the self-consistent radial wavefunctions, eigenvalues, charge
+  densities and potentials. The atomic densities can then be used to
+  initialise the crystal densities, and the atomic self-consistent potentials
+  can be appended to the muffin-tin potentials to solve for the core states.
+  Note that, irrespective of the value of {\tt xctype}, exchange-correlation
+  functional type 3 is used. See also {\tt atoms}, {\tt rhoinit},
+  {\tt gencore} and {\tt modxcifc}.
+
+  Created September 2002 (JKD)
+  Modified for GGA, June 2007 (JKD)
+  Modified for DFT-1/2, 2015 (Ronaldo)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE allatoms
+
+## Important Variables/Constants
+
+- `Character (256) :: fname` (No comment)
+- `Integer :: fnum_ = 333` (Comment:  file where Vs (see DFT-1/2 details) is written)
+- `Integer :: is, i, ir, n, nshell` (No comment)
+- `Integer :: xctypearray(3)` (No comment)
+- `Integer, Allocatable :: shell(:)` (No comment)
+- `Integer, Parameter :: xcgrad_ = 0` (No comment)
+- `Integer, Parameter :: xctype_ = 3` (No comment)
+- `Logical :: dirac_eq` (No comment)
+- `Real (8) :: ampl, cut, cutfunction, aux` (No comment)
+- `Real (8), Allocatable :: ionization(:)` (No comment)
+- `Real (8), Allocatable :: newspocc(:)` (No comment)
+- `Real (8), Allocatable :: rhoslave(:)` (No comment)
+- `Real (8), Allocatable :: rwf (:, :, :)` (No comment)
+- `Type (xmlf_t), Save :: xf` (No comment)
+- `character(100)::buffer` (No comment)
+- `integer :: verbosity` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- FoX_wxml
+- modinput
+- modmain
+- modmpi
+
+**Calls:**
+- atom
+- finitMPI
+- vhalfinit
+- xml_AddAttribute
+- xml_EndElement
+- xml_NewElement
+- xml_OpenFile
+- xml_close

--- a/docs/src_docs/asserts.F90.md
+++ b/docs/src_docs/asserts.F90.md
@@ -1,0 +1,34 @@
+# asserts.F90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- MODULE Procedure
+- MODULE asserts
+- SUBROUTINE assert_true
+- SUBROUTINE terminate
+
+## Important Variables/Constants
+
+- `Integer, Parameter :: error_code_logical = -101` (No comment)
+- `integer :: ierr` (No comment)
+- `logical, intent(in) :: logical_condition` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- iso_fortran_env
+- mpi
+- trace
+
+**Calls:**
+- MPI_ABORT
+- terminate
+- trace_back

--- a/docs/src_docs/atom.f90.md
+++ b/docs/src_docs/atom.f90.md
@@ -1,0 +1,65 @@
+# atom.f90
+
+## Overview
+
+  Solves the Dirac-Kohn-Sham equations for an atom using the
+  exchange-correlation functional {\tt xctype} and returns the self-consistent
+  radial wavefunctions, eigenvalues, charge densities and potentials. The
+  variable {\tt np} defines the order of polynomial used for performing
+  numerical integration. Requires the exchange-correlation interface routine
+  {\tt xcifc}.
+
+  Created September 2002 (JKD)
+  Fixed s.c. convergence problem, October 2003 (JKD)
+  Added support for GGA functionals, June 2006 (JKD)
+  Almost entirely rewritten 2013 (Andris)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE atom
+
+## Important Variables/Constants
+
+- `Integer :: ir, ist, iscl` (No comment)
+- `Integer, Intent (In) :: k (nst)` (No comment)
+- `Integer, Intent (In) :: l (nst)` (No comment)
+- `Integer, Intent (In) :: n (nst)` (No comment)
+- `Integer, Intent (In) :: nr,mtnr` (No comment)
+- `Integer, Intent (In) :: nst` (No comment)
+- `Integer, Intent (In) :: xcgrad` (No comment)
+- `Integer, Intent (In) :: xctype(3)` (No comment)
+- `Integer, Parameter :: maxscl = 500` (No comment)
+- `Logical, Intent (In) :: dirac_eq` (No comment)
+- `Logical, Intent (In) :: ptnucl` (No comment)
+- `Real (8) :: sum, dv, dvp, ze, beta, t1` (No comment)
+- `Real (8), Allocatable :: dwf1(:),dwf2(:),dwf3(:),dwf4(:)` (No comment)
+- `Real (8), Allocatable :: grho (:), g2rho (:), g3rho (:)` (No comment)
+- `Real (8), Intent (In) :: r (nr)` (No comment)
+- `Real (8), Intent (In) :: zn` (No comment)
+- `Real (8), Intent (Inout) :: occ (nst)` (No comment)
+- `Real (8), Intent (Out) :: eval (nst)` (No comment)
+- `Real (8), Intent (Out) :: rho (nr)` (No comment)
+- `Real (8), Intent (Out) :: rwf (nr, 2, nst)` (No comment)
+- `Real (8), Intent (Out) :: vr (nr)` (No comment)
+- `Real (8), Parameter :: alpha = 1.d0 / 137.03599911d0` (No comment)
+- `Real (8), Parameter :: eps = 1.d-8` (No comment)
+- `Real (8), Parameter :: fourpi = 12.566370614359172954d0` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modxcifc
+
+**Calls:**
+- fderiv
+- potnucl
+- rdirac
+- warning
+- xcifc

--- a/docs/src_docs/autoradmt.f90.md
+++ b/docs/src_docs/autoradmt.f90.md
@@ -1,0 +1,39 @@
+# autoradmt.f90
+
+## Overview
+
+  Automatically determines the muffin-tin radii from the formula
+  $$ R_i\propto 1+\zeta|Z_i|^{1/3}, $$
+  where $Z_i$ is the atomic number of the $i$th species, $\zeta$ is a
+  user-supplied constant ($\sim 0.625$). The parameter $\zeta$ is stored in
+  {\tt rmtapm(1)} and the value which governs the distance between the
+  muffin-tins is stored in {\tt rmtapm(2)}. When {\tt rmtapm(2)} $=1$, the
+  closest muffin-tins will touch.
+
+  Created March 2005 (JKD)
+  Changed the formula, September 2006 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE autoradmt
+
+## Important Variables/Constants
+
+- `Integer :: is, js, ia, ja, i1, i2, i3` (No comment)
+- `Real (8) :: r3dist` (No comment)
+- `Real (8) :: s, v1 (3), v2 (3), t1, t2, t3` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- *None identified.*

--- a/docs/src_docs/bandstr.f90.md
+++ b/docs/src_docs/bandstr.f90.md
@@ -1,0 +1,80 @@
+# bandstr.f90
+
+## Overview
+
+  Produces a band structure along the path in reciprocal-space which connects
+  the vertices in the array {\tt vvlp1d}. The band structure is obtained from
+  the second-variational eigenvalues and is written to the file {\tt BAND.OUT}
+  with the Fermi energy set to zero. If required, band structures are plotted
+  to files {\tt BAND\_Sss\_Aaaaa.OUT} for atom {\tt aaaa} of species {\tt ss},
+  which include the band characters for each $l$ component of that atom in
+  columns 4 onwards. Column 3 contains the sum over $l$ of the characters.
+  Vertex location lines are written to {\tt BANDLINES.OUT}.
+
+  Created June 2003 (JKD)
+  Modified June 2012 (DIN)
+  Modified March 2014 (UW)
+  Modified June 2018 (SeTi)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE bandstr
+
+## Important Variables/Constants
+
+- `Character (128) :: buffer` (No comment)
+- `Character (256) :: fname` (No comment)
+- `Complex (8), Allocatable :: apwalm (:, :, :, :, :)` (No comment)
+- `Complex (8), Allocatable :: dmat (:, :, :, :, :)` (No comment)
+- `Complex (8), Allocatable :: evecfv (:, :, :)` (No comment)
+- `Complex (8), Allocatable :: evecsv (:, :)` (No comment)
+- `Integer :: ik, ispn, is, ia, ias, iv, ist` (No comment)
+- `Integer :: lmax, lmmax, l, m, lm` (No comment)
+- `Real (4), Allocatable :: bc (:, :, :, :)` (No comment)
+- `Real (8) :: emin, emax, sum` (No comment)
+- `Real (8), Allocatable :: evalfv (:, :)` (No comment)
+- `Type (xmlf_t), Save :: xf` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- FoX_wxml
+- m_write_hdf5
+- modinput
+- modmain
+- modmpi
+
+**Calls:**
+- MPI_barrier
+- MTInitAll
+- MTNullify
+- genapwfr
+- gendmat
+- genlofr
+- genmeffig
+- hmlint
+- init0
+- init1
+- linengy
+- match
+- mpi_allgatherv_ifc
+- mt_hscf
+- olprad
+- readfermi
+- readstate
+- seceqn
+- terminate
+- write_bandstr_hdf5
+- xml_AddAttribute
+- xml_AddCharacters
+- xml_AddXMLPI
+- xml_NewElement
+- xml_OpenFile
+- xml_close
+- xml_endElement

--- a/docs/src_docs/borncharges.f90.md
+++ b/docs/src_docs/borncharges.f90.md
@@ -1,0 +1,49 @@
+# borncharges.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE borncharges
+- SUBROUTINE get
+- SUBROUTINE put
+
+## Important Variables/Constants
+
+- `character(*), intent( in) :: mode` (No comment)
+- `character(256) :: fname, buf` (No comment)
+- `integer :: ia, is, ias, ip, vi(3), un` (No comment)
+- `integer :: un, i, l, ias` (No comment)
+- `integer :: un` (No comment)
+- `logical :: exist` (No comment)
+- `logical, intent( in)      :: sumrule` (No comment)
+- `real(8) :: vr(3)` (No comment)
+- `real(8), intent( in)      :: pol(3,2,3,natmtot), disp` (No comment)
+- `real(8), intent( in) :: z(3,3,0:natmtot)` (No comment)
+- `real(8), intent( inout)   :: zstar(3,3,0:natmtot)` (No comment)
+- `real(8), intent( out) :: z(3,3,0:natmtot)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- m_getunit
+- mod_atoms
+- mod_lattice
+- mod_misc
+- modinput
+- modmpi
+
+**Calls:**
+- barrier
+- get
+- getunit
+- put
+- r3mv
+- r3ws
+- terminate

--- a/docs/src_docs/charge.f90.md
+++ b/docs/src_docs/charge.f90.md
@@ -1,0 +1,36 @@
+# charge.f90
+
+## Overview
+
+  Computes the muffin-tin, interstitial and total charges by integrating the
+  density.
+
+  Created April 2003 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE charge
+
+## Important Variables/Constants
+
+- `Integer :: is, ia, ias, ir` (No comment)
+- `Real (8) :: fr (nrmtmax), gr (nrmtmax), cf (3, nrmtmax)` (No comment)
+- `Real (8) :: sum, t1` (No comment)
+- `character(1024) :: message` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- modinput
+- modmain
+
+**Calls:**
+- fderiv
+- warning

--- a/docs/src_docs/checkinput.F90.md
+++ b/docs/src_docs/checkinput.F90.md
@@ -1,0 +1,27 @@
+# checkinput.F90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE checkinput
+
+## Important Variables/Constants
+
+- `character(1024) :: message` (No comment)
+- `integer :: is,i` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- *None identified.*

--- a/docs/src_docs/checkmt.f90.md
+++ b/docs/src_docs/checkmt.f90.md
@@ -1,0 +1,35 @@
+# checkmt.f90
+
+## Overview
+
+  Checks for overlapping muffin-tins. If any muffin-tins are found to
+  intersect the program is terminated with error.
+
+  Created May 2003 (JKD)
+  Revised October 2014 (PAS)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE checkmt
+
+## Important Variables/Constants
+
+- `Integer :: i1, i2, i3` (No comment)
+- `Integer :: ia, is, ja, js` (No comment)
+- `Real (8) :: t1, t2` (No comment)
+- `Real (8) :: v1(3), v2(3), v3(3)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- *None identified.*

--- a/docs/src_docs/chgdist.F90.md
+++ b/docs/src_docs/chgdist.F90.md
@@ -1,0 +1,44 @@
+# chgdist.F90
+
+## Overview
+
+  Calculated the charge distance between two charge densities of the current
+  and of the last iteration according to
+  the expression
+  $$
+    \Delta Q = \int_{\Omega} {\rm d}^3 r [\rho^{(n)}({\bf r}) -
+    \rho^{(n-1)}({\bf r})].
+  $$
+  Based on the routine {\tt charge}.
+
+  Created 2010 (Sagmeister)
+  Modified 2014 (DIN)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE chgdist
+
+## Important Variables/Constants
+
+- `Integer :: is, ia, ias, ir` (No comment)
+- `real(8) :: cf (3, nrmtmax), sht00(lmmaxvr)` (No comment)
+- `real(8) :: fr (nrmtmax), gr (nrmtmax), hr1(lmmaxvr), hr2(lmmaxvr)` (No comment)
+- `real(8) :: sum, chgdstmt, chgdstir` (No comment)
+- `real(8), intent(in) :: rhoirref(ngrtot)` (No comment)
+- `real(8), intent(in) :: rhomtref(lmmaxvr,nrmtmax,natmtot)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- modmain
+
+**Calls:**
+- dgemv
+- fderiv

--- a/docs/src_docs/constants.f90.md
+++ b/docs/src_docs/constants.f90.md
@@ -1,0 +1,27 @@
+# constants.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- MODULE constants
+
+## Important Variables/Constants
+
+- `complex(dp), public, parameter, dimension(2, 2) :: sigma_x = reshape(&` (No comment)
+- `complex(dp), public, parameter, dimension(2, 2) :: sigma_y = reshape(&` (No comment)
+- `complex(dp), public, parameter, dimension(2, 2) :: sigma_z = reshape(&` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- precision
+
+**Calls:**
+- *None identified.*

--- a/docs/src_docs/core_overlap.f90.md
+++ b/docs/src_docs/core_overlap.f90.md
@@ -1,0 +1,91 @@
+# core_overlap.f90
+
+## Overview
+
+Calculates the overlap between a selected group of core states and the
+valence and conduction states. While we assume that the overlap between
+these states vanishes, there is finite overlap since the two groups of
+states are obtained from different Hamiltonians. The overlap
+$\int dr^3 \psi^*_{\mu}(\mathbf{r})\psi_{i\mathbf{k}}(\mathbf{r})$ between
+a core state $\psi_{\mu \mathbf{k}}$ and valence/conduction state
+$\psi_{i\mathbf{k}}$ and energy differences $\Delta \epsilon=\epsilon_{i
+\mathbf{k}}-\epsilon_{\mu}$ are stored either in xml or hdf5 file.
+  Created December 2020 (Christian Vorwerk) based on bandstr.f90
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE core_overlap
+
+## Important Variables/Constants
+
+- `Character (128) :: buffer` (No comment)
+- `Complex (8), Allocatable :: apwalmt (:, :, :, :)` (No comment)
+- `Complex (8), Allocatable :: evecfv (:, :)` (No comment)
+- `Complex (8), Allocatable :: evecsv (:, :)` (No comment)
+- `Complex (8), Allocatable :: overlap(:,:,:)` (No comment)
+- `Complex (8), Allocatable :: wfmt(:,:,:)` (No comment)
+- `Integer :: ik, is, ia, ias, ist1, ist2, irc, ir` (No comment)
+- `Integer :: lm1, lm2` (No comment)
+- `Integer :: lxas` (No comment)
+- `Real (8), Allocatable :: evalfv (:,:)` (No comment)
+- `Real(8) :: t1, t2` (No comment)
+- `Real(8), Allocatable     :: de(:,:,:)` (No comment)
+- `Real(8), Allocatable :: cf(:,:)` (No comment)
+- `Real(8), Allocatable :: fr0(:), fr1(:), fr2(:), gr(:)` (No comment)
+- `Type (xmlf_t), Save :: xf` (No comment)
+- `character(*), parameter :: thisname="writeoverlap"` (No comment)
+- `character(256) :: cik` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- FoX_wxml
+- constants
+- mod_APW_LO
+- mod_Gkvector
+- mod_atoms
+- mod_eigensystem
+- mod_eigenvalue_occupancy
+- mod_hdf5
+- mod_kpoint
+- mod_muffin_tin
+- mod_spin
+- modinput
+- modmpi
+- modxas
+- mpi
+
+**Calls:**
+- MTInitAll
+- MTNullify
+- coreinit
+- fderiv
+- genapwfr
+- genlofr
+- genmeffig
+- hdf5_create_group
+- hdf5_write
+- hmlint
+- init0
+- init1
+- linengy
+- match
+- mpi_allgatherv_ifc
+- mt_hscf
+- olprad
+- readfermi
+- readstate
+- seceqn
+- wavefmt
+- xml_AddAttribute
+- xml_AddXMLPI
+- xml_NewElement
+- xml_OpenFile
+- xml_close
+- xml_endElement

--- a/docs/src_docs/dbxcplot.f90.md
+++ b/docs/src_docs/dbxcplot.f90.md
@@ -1,0 +1,41 @@
+# dbxcplot.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE dbxcplot
+
+## Important Variables/Constants
+
+- `Integer :: idm, is, ia, ias, ir` (No comment)
+- `Real (8), Allocatable :: grfir (:, :)` (No comment)
+- `Real (8), Allocatable :: grfmt (:, :, :, :)` (No comment)
+- `Real (8), Allocatable :: rfir (:)` (No comment)
+- `Real (8), Allocatable :: rfmt (:, :, :)` (No comment)
+- `Real (8), Allocatable :: rvfir (:, :)` (No comment)
+- `Real (8), Allocatable :: rvfmt (:, :, :, :)` (No comment)
+- `type(plotlabels),pointer ::labels` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+- modplotlabels
+
+**Calls:**
+- destroy_plotlablels
+- gradrf
+- init0
+- plot1d
+- plot2d
+- plot3d
+- readstate
+- set_plotlabel_axis

--- a/docs/src_docs/delevec.f90.md
+++ b/docs/src_docs/delevec.f90.md
@@ -1,0 +1,25 @@
+# delevec.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE delevec
+
+## Important Variables/Constants
+
+- `Logical :: exist` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modmain
+
+**Calls:**
+- *None identified.*

--- a/docs/src_docs/dipole_correction.f90.md
+++ b/docs/src_docs/dipole_correction.f90.md
@@ -1,0 +1,39 @@
+# dipole_correction.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE dipole_correction
+
+## Important Variables/Constants
+
+- `integer :: i1, i2, i3` (No comment)
+- `integer :: is, ia, ias, ir` (No comment)
+- `integer :: ivac` (No comment)
+- `integer, allocatable :: idx(:)` (No comment)
+- `real(8) :: dplmt, dplir, dpl, zm, z, z0` (No comment)
+- `real(8) :: fr(nrmtmax), gr(nrmtmax), cf(3,nrmtmax)` (No comment)
+- `real(8) :: rfinp` (No comment)
+- `real(8) :: t1, t2, rv(3), norm(3), A` (No comment)
+- `real(8), allocatable :: tmat(:,:,:), rhoz(:)` (No comment)
+- `real(8), intent(out) :: vdplir(ngrtot)` (No comment)
+- `real(8), intent(out) :: vdplmt(lmmaxvr,nrmtmax,natmtot)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- modinput
+- modmain
+- modmpi
+
+**Calls:**
+- fderiv
+- r3cross

--- a/docs/src_docs/dos.f90.md
+++ b/docs/src_docs/dos.f90.md
@@ -1,0 +1,117 @@
+# dos.f90
+
+## Overview
+
+  Produces a total and partial density of states (DOS) for plotting. The total
+  DOS is written to the file {\tt TDOS.OUT} while the partial DOS is written
+  to the file {\tt PDOS\_Sss\_Aaaaa.OUT} for atom {\tt aaaa} of species
+  {\tt ss}. In the case of the partial DOS, each symmetrised
+  $(l,m)$-projection is written consecutively and separated by blank lines.
+  If the global variable {\tt lmirep} is {\tt .true.}, then the density matrix
+  from which the $(l,m)$-projections are obtained is first rotated into a
+  irreducible representation basis, i.e. one that block diagonalises all the
+  site symmetry matrices in the $Y_{lm}$ basis. Eigenvalues of a quasi-random
+  matrix in the $Y_{lm}$ basis which has been symmetrised with the site
+  symmetries are written to {\tt ELMIREP.OUT}. This allows for identification
+  of the irreducible representations of the site symmetries, for example $e_g$
+  or $t_{2g}$, by the degeneracies of the eigenvalues. In the plot, spin-up is
+  made positive and spin-down negative. See the routines {\tt gendmat} and
+  {\tt brzint}.
+
+  Created January 2004 (JKD)
+  Added more efficient trilinear integration and tetrahedron integration, August 2020 (SeTi)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE dos
+
+## Important Variables/Constants
+
+- `Character (256) :: fname` (No comment)
+- `Character (512) :: buffer` (No comment)
+- `Character(256) :: string` (No comment)
+- `Complex (8), Allocatable :: a (:, :)` (No comment)
+- `Complex (8), Allocatable :: apwalm (:, :, :, :, :)` (No comment)
+- `Complex (8), Allocatable :: dmat (:, :, :, :, :)` (No comment)
+- `Complex (8), Allocatable :: evecfv (:, :, :)` (No comment)
+- `Complex (8), Allocatable :: evecsv (:, :)` (No comment)
+- `Complex (8), Allocatable :: sdmat (:, :, :, :)` (No comment)
+- `Complex (8), Allocatable :: ulm (:, :, :)` (No comment)
+- `Integer :: Ndosspn, spinor_factor` (No comment)
+- `Integer :: idosspn` (No comment)
+- `Integer :: ik, nsk (3), ist, iw, jst, n, i` (No comment)
+- `Integer :: ispn, jspn, is, ia, ias` (No comment)
+- `Integer :: lmax, lmmax, l, m, lm` (No comment)
+- `Integer :: ntrans, mtrans` (No comment)
+- `Integer, dimension(2) :: sign_factor = (/1.d0, -1.d0/)` (No comment)
+- `Logical :: lonly` (No comment)
+- `Logical :: tsqaz` (No comment)
+- `Real (4), Allocatable :: bc (:, :, :, :, :)` (No comment)
+- `Real (8) :: dw, th, t1` (No comment)
+- `Real (8) :: v1 (3), v2 (3), v3 (3)` (No comment)
+- `Real (8), Allocatable :: dosg(:,:), dosgl(:,:,:)` (No comment)
+- `Real (8), Allocatable :: e (:, :, :)` (No comment)
+- `Real (8), Allocatable :: edif(:,:,:), ej(:,:), fj(:,:)` (No comment)
+- `Real (8), Allocatable :: elm (:, :)` (No comment)
+- `Real (8), Allocatable :: f (:, :)` (No comment)
+- `Real (8), Allocatable :: g(:,:), gp(:)` (No comment)
+- `Real (8), Allocatable :: jdos (:, :, :), jdosocc (:, :, :)` (No comment)
+- `Real (8), Allocatable :: w (:)` (No comment)
+- `Real (8), Allocatable :: wgt (:, :, :)` (No comment)
+- `Type (xmlf_t), Save :: xf` (No comment)
+- `type( k_set) :: kset` (No comment)
+- `type( t_set) :: tset` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- FoX_wxml
+- mod_eigenvalue_occupancy
+- mod_kpointset
+- mod_lattice
+- mod_opt_tetra
+- modinput
+- modmain
+- modmpi
+
+**Calls:**
+- axangsu2
+- brzint
+- brzint_new
+- delete_k_vectors
+- fsmooth
+- genapwfr
+- gendmat
+- generate_k_vectors
+- genlofr
+- gensdmat
+- getevalsv
+- getevecfv
+- getevecsv
+- getoccsv
+- init0
+- init1
+- linengy
+- match
+- opt_tetra_destroy
+- opt_tetra_init
+- opt_tetra_int_deltadiff
+- opt_tetra_wgt_delta
+- r3cross
+- readfermi
+- readstate
+- xml_AddAttribute
+- xml_AddCharacters
+- xml_NewElement
+- xml_OpenFile
+- xml_close
+- xml_endElement
+- z2mm
+- z2mmct
+- zgemm

--- a/docs/src_docs/effmass.f90.md
+++ b/docs/src_docs/effmass.f90.md
@@ -1,0 +1,63 @@
+# effmass.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE effmass
+
+## Important Variables/Constants
+
+- `Complex (8), Allocatable :: evecfv (:, :, :)` (No comment)
+- `Complex (8), Allocatable :: evecsv (:, :)` (No comment)
+- `Integer :: i, j, k, l, m, n` (No comment)
+- `Integer :: i1, i2, i3, j1, j2, j3` (No comment)
+- `Integer :: ik, ik0, ist, info` (No comment)
+- `Integer, Allocatable :: ipiv (:)` (No comment)
+- `Integer, Parameter :: lwork = 10` (No comment)
+- `Real (8) :: d (3, 3), em (3, 3)` (No comment)
+- `Real (8) :: v1 (3), v2 (3)` (No comment)
+- `Real (8) :: w (3), work (lwork)` (No comment)
+- `Real (8), Allocatable :: a (:, :)` (No comment)
+- `Real (8), Allocatable :: b (:, :, :, :)` (No comment)
+- `Real (8), Allocatable :: c (:, :, :)` (No comment)
+- `Real (8), Allocatable :: evalfv (:, :)` (No comment)
+- `Type (xmlf_t), Save :: xf` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- Fox_wxml
+- modinput
+- modmain
+
+**Calls:**
+- MTInitAll
+- MTNullify
+- dgesv
+- dsyev
+- genapwfr
+- genlofr
+- genmeffig
+- hmlint
+- init0
+- init1
+- linengy
+- mt_hscf
+- olprad
+- r3minv
+- r3mv
+- readstate
+- seceqn
+- xml_AddAttribute
+- xml_AddCharacters
+- xml_Close
+- xml_EndElement
+- xml_NewElement
+- xml_OpenFile

--- a/docs/src_docs/elfplot.f90.md
+++ b/docs/src_docs/elfplot.f90.md
@@ -1,0 +1,85 @@
+# elfplot.f90
+
+## Overview
+
+  Outputs the electron localisation function (ELF) for 1D, 2D or 3D plotting.
+  The spin-averaged ELF is given by
+  $$ f_{\rm ELF}({\bf r})=\frac{1}{1+[D({\bf r})/D^0({\bf r})]^2}, $$
+  where
+  $$ D({\bf r})=\frac{1}{2}\left(\tau({\bf r})-\frac{1}{4}
+   \frac{[\nabla n({\bf r})]^2}{n({\bf r})}\right) $$
+  and
+  $$ \tau({\bf r})=\sum_{i=1}^N \left|\nabla\Psi_i({\bf r})
+   \right|^2 $$
+  is the spin-averaged kinetic energy density from the spinor wavefunctions.
+  The function $D^0$ is the kinetic energy density for the homogeneous
+  electron gas evaluated for $n({\bf r})$:
+  $$ D^0({\bf r})=\frac{3}{5}(6\pi^2)^{2/3}\left(\frac{n({\bf r})}{2}
+   \right)^{5/3}. $$
+  The ELF is useful for the topological classification of bonding. See for
+  example T. Burnus, M. A. L. Marques and E. K. U. Gross [Phys. Rev. A 71,
+  10501 (2005)].
+
+  Created September 2003 (JKD)
+  Fixed bug found by F. Wagner (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE elfplot
+
+## Important Variables/Constants
+
+- `Character(256) :: string` (No comment)
+- `Complex (8), Allocatable :: evecfv (:, :)` (No comment)
+- `Complex (8), Allocatable :: evecsv (:, :)` (No comment)
+- `Complex (8), Allocatable :: zfft1 (:), zfft2 (:)` (No comment)
+- `Integer :: ik, is, ia, ias` (No comment)
+- `Integer :: ir, i, itp, ig, ifg` (No comment)
+- `Real (8) :: t1, t2` (No comment)
+- `Real (8), Allocatable :: elfir (:)` (No comment)
+- `Real (8), Allocatable :: elfmt (:, :, :)` (No comment)
+- `Real (8), Allocatable :: grfir (:)` (No comment)
+- `Real (8), Allocatable :: grfmt (:, :, :)` (No comment)
+- `Real (8), Allocatable :: gwf2ir (:)` (No comment)
+- `Real (8), Allocatable :: gwf2mt (:, :, :)` (No comment)
+- `Real (8), Allocatable :: rftp1 (:), rftp2 (:), rftp3 (:)` (No comment)
+- `type(plotlabels),pointer ::labels` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- modinput
+- modmain
+- modmpi
+- modplotlabels
+
+**Calls:**
+- destroy_plotlablels
+- dgemv
+- genapwfr
+- gencore
+- genlofr
+- getevecfv
+- getevecsv
+- getoccsv
+- gradrfmt
+- gwf2cr
+- gwf2val
+- init0
+- init1
+- linengy
+- plot1d
+- plot2d
+- plot3d
+- readfermi
+- readstate
+- set_plotlabel_axis
+- symrf
+- zfftifc

--- a/docs/src_docs/emat_wannier.f90.md
+++ b/docs/src_docs/emat_wannier.f90.md
@@ -1,0 +1,69 @@
+# emat_wannier.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE emat_wannier
+
+## Important Variables/Constants
+
+- `Complex (8), Allocatable :: apwalm1 (:, :, :, :)` (No comment)
+- `Complex (8), Allocatable :: apwalm2 (:, :, :, :)` (No comment)
+- `Complex (8), Allocatable :: em (:, :)` (No comment)
+- `Complex (8), Allocatable :: evecfv1 (:, :)` (No comment)
+- `Complex (8), Allocatable :: evecfv2 (:, :)` (No comment)
+- `Complex (8), Allocatable :: evecsv1 (:, :)` (No comment)
+- `Complex (8), Allocatable :: evecsv2 (:, :)` (No comment)
+- `Complex (8), Allocatable :: sfacgkq (:, :)` (No comment)
+- `Complex (8), Allocatable :: wfir (:)` (No comment)
+- `Complex (8), Allocatable :: wfmt1 (:, :)` (No comment)
+- `Complex (8), Allocatable :: wfmt2 (:, :, :)` (No comment)
+- `Complex (8), Allocatable :: wfmt3 (:, :)` (No comment)
+- `Complex (8), Allocatable :: zfir1 (:)` (No comment)
+- `Complex (8), Allocatable :: zfir2 (:)` (No comment)
+- `Complex (8), Intent (Out) :: emat (nst1, nst2)` (No comment)
+- `Integer :: i, j, k, l, ispn` (No comment)
+- `Integer :: is, ia, i1, i2, i3, iv (3)` (No comment)
+- `Integer :: l1, l2, l3, m1, m2, m3` (No comment)
+- `Integer :: lm1, lm2, lm3, ist, jst` (No comment)
+- `Integer :: ngkq, igk, ifg, ir, irc` (No comment)
+- `Integer, Allocatable :: igkqig (:)` (No comment)
+- `Integer, Intent (In) :: ik, fst1, nst1, fst2, nst2` (No comment)
+- `Real (8) :: gaunt` (No comment)
+- `Real (8) :: v1 (3), v2 (3), v3 (3)` (No comment)
+- `Real (8) :: vecqc (3), qc, tp (2)` (No comment)
+- `Real (8) :: vkql (3), vkqc (3), x, t1` (No comment)
+- `Real (8), Allocatable :: gkqc (:)` (No comment)
+- `Real (8), Allocatable :: gnt (:, :, :)` (No comment)
+- `Real (8), Allocatable :: jlqr (:, :)` (No comment)
+- `Real (8), Allocatable :: tpgkqc (:, :)` (No comment)
+- `Real (8), Allocatable :: vgkqc (:, :)` (No comment)
+- `Real (8), Allocatable :: vgkql (:, :)` (No comment)
+- `real(8), intent( in) :: vecql(3)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- modinput
+- modmain
+
+**Calls:**
+- gengpvec
+- gensfacgp
+- genylm
+- getevecfv
+- match
+- r3frac
+- r3mv
+- sbessel
+- sphcrd
+- wavefmt
+- zfftifc

--- a/docs/src_docs/energy.f90.md
+++ b/docs/src_docs/energy.f90.md
@@ -1,0 +1,119 @@
+# energy.f90
+
+## Overview
+
+  The {\tt energy} subroutine computes the total energy and its individual contributions.
+  The total energy is composed of kinetic, Coulomb, and exchange-correlation energy,
+  %
+  \begin{equation}
+   E_{\rm tot}\,=\,T_{\rm s}\,+\,E_{C}\,+\,E_{\rm xc}.
+  \end{equation}
+  %
+  The kinetic energy of the non-interacting system is given by
+  %
+  \begin{equation}
+   T_{\rm s} = \sum_i n_i\epsilon_i \, - \, V_{\rm eff},
+  \label{kinetic}
+  \end{equation}
+  %
+  where $n_i$ are the occupancies and $\epsilon_i$ are the eigenvalues of both the core and
+  valence states. The effective potential energy, $V_{\rm eff}$, can be expressed as
+  %
+  \begin{eqnarray}
+   V_{\rm eff}\,&=&\,\int\rho({\bf r}) \, v_{\rm C}({\bf r}) \, d{\bf r} + \int\rho({\bf r}) \, v_{\rm xc}({\bf r})\,d{\bf r} \nonumber \\
+                &+&\int {\bf m}({\bf r})\cdot\left[{\bf B}_{\rm xc}({\bf r})+{\bf B}_{\rm ext}({\bf r})\right]\,d{\bf r}.
+  \label{Eeff}
+  \end{eqnarray}
+  %
+  The first and second term of Eq.~(\ref{Eeff}) are the Coulomb potential energy, $V_{C}$, and
+  exchange-correlation potential energy, $V_{\rm xc}$, respectively. ${\bf m}({\bf r})$ is the
+  magnetization density, and ${\bf B}_{\rm xc}$ and ${\bf B}_{\rm ext}$ are the
+  exchange-correlation effective magnetic and the external magnetic fields, respectively.
+
+  The Coulomb energy consists of the Hartree energy, $E_{\rm H}$, the electron-nuclear energy, $
+  E_{\rm en}$, and the nuclear-nuclear energy, $E_{\rm nn}$,
+  %
+  \begin{eqnarray}
+   E_{\rm C}\,&=&\,E_{\rm H}\,+\,E_{\rm en}\,+\,E_{\rm nn} \nonumber \\
+              &=&\,(\underbrace{E_{\rm H}\,+\,\frac{1}{2}E_{\rm en}})\,+\,(\underbrace{\frac{1}{2}E_{\rm en}\,+\,E_{\rm nn}}) \nonumber \\
+              &=&\, \hspace{8mm} \frac{1}{2}V_{\rm C} \hspace{9.5mm} + \hspace{9mm} E_{\rm Madelung}.
+  \label{Eq4}
+  \end{eqnarray}
+  %
+  The Madelung energy is given by
+  %
+  \begin{eqnarray}
+  E_{\rm Madelung}=\frac{1}{2}\sum_{\alpha}z_{\alpha}R_{\alpha},
+  \end{eqnarray}
+  where for each atom $\alpha$ with nuclear charge $z_{\alpha}$
+  %
+  \begin{eqnarray}
+   R_{\alpha}=\lim_{r\rightarrow 0}\left(v^{\rm C}_{\alpha,00}(r)Y_{00} +\frac{z_{\alpha}}{r}\right)
+  \end{eqnarray}
+  %
+  with $v^{\rm C}_{\alpha,00}$ being the $l=0$ component of the spherical harmonic expansion of
+  $v_{\rm C}$ in the muffin-tin region. Using Eq.~(\ref{Eq4}), the electron-nuclear and Hartree
+  energies can be expressed as
+  %
+  \begin{eqnarray}
+   E_{\rm en}=2\left(E_{\rm Madelung}-E_{\rm nn}\right)
+  \end{eqnarray}
+  %
+  and
+  %
+  \begin{eqnarray}
+   E_{\rm H}=\frac{1}{2}(V_{\rm C}-E_{\rm en}).
+  \end{eqnarray}
+  %
+  $E_{\rm xc}$ is obtained either by integrating the exchange-correlation energy density,
+  %
+  \begin{eqnarray}
+   E_{\rm xc}\,=\, \int \rho({\bf r})\,\epsilon_{\rm xc}({\bf r})\,d{\bf r},
+  \end{eqnarray}
+  %
+  or in the case of exact exchange, the explicit calculation of the Fock exchange integral.
+
+  The energy from the external magnetic fields in the muffin-tins, {\tt bfcmt}, is always
+  removed from the total since these fields are non-physical: their field lines do not close.
+  The energy of the physical external field, {\tt bfieldc}, is also not included in the total
+  because this field, like those in the muffin-tins, is used for breaking spin symmetry and
+  taken to be infinitesimal. If this field is intended to be finite, then the associated energy,
+  {\tt engybext}, should be added to the total by hand.
+  See {\tt potxc}, {\tt exxengy} and related subroutines.
+
+  Created Jun 2013
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE energy
+
+## Important Variables/Constants
+
+- `Complex (8), Allocatable :: evecsv (:, :), c (:, :)` (No comment)
+- `Integer :: is, ia, ias, ik, ist, idm, jdm, ir, lm` (No comment)
+- `Real (8) :: v2(50)` (No comment)
+- `Real (8) :: vn` (No comment)
+- `Real (8), Parameter :: alpha = 1.d0 / 137.03599911d0` (No comment)
+- `Real (8), Parameter :: ga4 = ge * alpha / 4.d0` (No comment)
+- `Real (8), Parameter :: ge = 2.0023193043718d0` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- mod_hybrids
+- modinput
+- modmain
+
+**Calls:**
+- DFT_D2_energy
+- TS_vdW_energy
+- energykncr
+- getevecsv
+- potnucl
+- zgemm

--- a/docs/src_docs/energykncr.f90.md
+++ b/docs/src_docs/energykncr.f90.md
@@ -1,0 +1,27 @@
+# energykncr.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE energykncr
+
+## Important Variables/Constants
+
+- `Integer :: is, ia, ias, ist, ir` (No comment)
+- `Real (8) :: rfmtinp` (No comment)
+- `Real (8), Allocatable :: rfmt (:, :)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modmain
+
+**Calls:**
+- *None identified.*

--- a/docs/src_docs/energynn.f90.md
+++ b/docs/src_docs/energynn.f90.md
@@ -1,0 +1,34 @@
+# energynn.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE energynn
+
+## Important Variables/Constants
+
+- `Complex (8), Allocatable :: zrhoir (:)` (No comment)
+- `Complex (8), Allocatable :: zrhomt (:, :, :)` (No comment)
+- `Complex (8), Allocatable :: zvclir (:)` (No comment)
+- `Complex (8), Allocatable :: zvclmt (:, :, :)` (No comment)
+- `Integer :: is, ia, ias, lmax` (No comment)
+- `Real (8) :: vn, t1` (No comment)
+- `Real (8), Allocatable :: jlgr (:, :, :)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- genjlgpr
+- potnucl
+- zpotcoul

--- a/docs/src_docs/eqpongrid.f90.md
+++ b/docs/src_docs/eqpongrid.f90.md
@@ -1,0 +1,36 @@
+# eqpongrid.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE eqpongrid
+
+## Important Variables/Constants
+
+- `character(30) :: fname` (No comment)
+- `integer :: nkp, ibgw, nbgw` (No comment)
+- `integer :: nv, ik, nk, ib, nb, iknr, is, iv, m, ix, iy, iz` (No comment)
+- `integer(4)    :: recl` (No comment)
+- `logical :: exist` (No comment)
+- `real(8) :: eferqp, eferks` (No comment)
+- `real(8) :: s(3), v1(3), dt, vk(3)` (No comment)
+- `real(8), allocatable :: eval2(:,:), vvl(:,:), ongrid(:,:)` (No comment)
+- `real(8), allocatable :: kvecs(:,:), eqp(:,:), eks(:,:)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- mod_wannier
+- modinput
+- modmain
+
+**Calls:**
+- findkpt
+- r3mv

--- a/docs/src_docs/errors_warnings.f90.md
+++ b/docs/src_docs/errors_warnings.f90.md
@@ -1,0 +1,28 @@
+# errors_warnings.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- MODULE errors_warnings
+- SUBROUTINE terminate_if_false
+
+## Important Variables/Constants
+
+- `character(len=*), intent(in) :: error_message` (No comment)
+- `logical, intent(in) :: consistent` (No comment)
+- `type(mpiinfo), intent(inout) :: mpiglobal` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modmpi
+
+**Calls:**
+- terminate_mpi_env

--- a/docs/src_docs/fermisurf.f90.md
+++ b/docs/src_docs/fermisurf.f90.md
@@ -1,0 +1,46 @@
+# fermisurf.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE fermisurf
+
+## Important Variables/Constants
+
+- `complex(8), allocatable :: evecfv(:,:,:)` (No comment)
+- `complex(8), allocatable :: evecsv(:,:)` (No comment)
+- `integer :: fnum,fnum0,fnum1` (No comment)
+- `integer :: ik,ist,ist0,ist1` (No comment)
+- `integer :: lst,nst,i,i1,i2,i3,j1,j2,j3` (No comment)
+- `real(8) :: vc(3,4)` (No comment)
+- `real(8), allocatable :: evalfv(:,:)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modmain
+- modmpi
+
+**Calls:**
+- MTInitAll
+- MTNullify
+- genapwfr
+- genlofr
+- genmeffig
+- hmlint
+- init0
+- init1
+- linengy
+- mpi_allgatherv_ifc
+- mt_hscf
+- olprad
+- readfermi
+- readstate
+- seceqn

--- a/docs/src_docs/findband.f90.md
+++ b/docs/src_docs/findband.f90.md
@@ -1,0 +1,62 @@
+# findband.f90
+
+## Overview
+
+  Finds the band energies for a given radial potential and angular momentum.
+  This is done by first searching upwards in energy until the radial
+  wavefunction at the muffin-tin radius is zero. This is the energy at the top
+  of the band, denoted $E_{\rm t}$. A downward search is now performed from
+  $E_{\rm t}$ until the slope of the radial wavefunction at the muffin-tin
+  radius is zero. This energy, $E_{\rm b}$, is at the bottom of the band. The
+  band energy is taken as $(E_{\rm t}+E_{\rm b})/2$. If either $E_{\rm t}$ or
+  $E_{\rm b}$ cannot be found then the band energy is set to the input value.
+
+  Created September 2004 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE findband
+
+## Important Variables/Constants
+
+- `Character (*), Intent (In) :: findlinentype` (No comment)
+- `Integer :: ie, nn` (No comment)
+- `Integer, Intent(In)    :: k` (No comment)
+- `Integer, Intent(In)    :: l` (No comment)
+- `Integer, Intent(In)    :: nr` (No comment)
+- `Integer, Parameter :: maxstp = 1000` (No comment)
+- `Real (8) :: de, e, t0, t1, t00, t10, dl, dl0` (No comment)
+- `Real (8) :: e1, e2, eidn, eiup` (No comment)
+- `Real (8) :: p0 (nr), p1 (nr), q0 (nr), q1 (nr)` (No comment)
+- `Real (8), Parameter :: ecutlow = - 100.d0` (No comment)
+- `Real (8), Parameter :: edefault1 = 1.d0` (No comment)
+- `Real (8), Parameter :: ediffusebands = efermibands + erangebands` (No comment)
+- `Real (8), Parameter :: edncut = -10.d0` (No comment)
+- `Real (8), Parameter :: efermibands = 0.5d0` (No comment)
+- `Real (8), Parameter :: erange1 = 3.d0` (No comment)
+- `Real (8), Parameter :: erangebands = 1.d0` (No comment)
+- `Real (8), Parameter :: etoolow = - 1000.d0` (No comment)
+- `Real (8), Parameter :: eupcut = 30.d0` (No comment)
+- `Real(8), Intent(In)    :: de0` (No comment)
+- `Real(8), Intent(In)    :: r (nr)` (No comment)
+- `Real(8), Intent(In)    :: vr (nr)` (No comment)
+- `Real(8), Intent(Inout) :: e0` (No comment)
+- `character(10) :: fname` (No comment)
+- `character(1024) :: message` (No comment)
+- `logical, intent(out)   :: tfnd` (No comment)
+- `real(8), intent(in)    :: etol` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modmain
+
+**Calls:**
+- rschroddme
+- warning

--- a/docs/src_docs/findequivkpt.f90.md
+++ b/docs/src_docs/findequivkpt.f90.md
@@ -1,0 +1,34 @@
+# findequivkpt.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE findequivkpt
+
+## Important Variables/Constants
+
+- `integer :: iq, is, lspl, iv(3)` (No comment)
+- `integer, intent( out) :: ik( kset%nkpt)` (No comment)
+- `integer, intent( out) :: isym( kset%nkpt)` (No comment)
+- `integer, intent( out) :: nk` (No comment)
+- `real(8) :: s(3,3), v1(3), v2(3), t1` (No comment)
+- `real(8), intent( in) :: vpl(3)` (No comment)
+- `type( k_set), intent( in) :: kset` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- mod_kpointset
+- modinput
+- modmain
+
+**Calls:**
+- r3frac
+- r3mtv

--- a/docs/src_docs/findigp0.f90.md
+++ b/docs/src_docs/findigp0.f90.md
@@ -1,0 +1,30 @@
+# findigp0.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE findigp0
+
+## Important Variables/Constants
+
+- `Integer :: igp` (No comment)
+- `Integer, Intent (In) :: ngp` (No comment)
+- `Integer, Intent (Out) :: igp0` (No comment)
+- `Real (8) :: t1` (No comment)
+- `Real (8), Intent (In) :: gpc (ngp)` (No comment)
+- `Real (8), Parameter :: eps = 1.d-14` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- *None identified.*
+
+**Calls:**
+- *None identified.*

--- a/docs/src_docs/findkpt.f90.md
+++ b/docs/src_docs/findkpt.f90.md
@@ -1,0 +1,32 @@
+# findkpt.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE findkpt
+
+## Important Variables/Constants
+
+- `Integer :: lspl, iv (3)` (No comment)
+- `Integer, Intent (Out) :: ik` (No comment)
+- `Integer, Intent (Out) :: isym` (No comment)
+- `Real (8) :: s (3, 3), v1 (3), v2 (3), t1` (No comment)
+- `Real (8), Intent (In) :: vpl (3)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- mod_kpoint
+- mod_symmetry
+- modinput
+
+**Calls:**
+- r3frac
+- r3mtv

--- a/docs/src_docs/findkptinset.f90.md
+++ b/docs/src_docs/findkptinset.f90.md
@@ -1,0 +1,33 @@
+# findkptinset.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE findkptinset
+
+## Important Variables/Constants
+
+- `integer :: lspl, iv(3)` (No comment)
+- `integer, intent( out) :: ik` (No comment)
+- `integer, intent( out) :: isym` (No comment)
+- `real(8) :: s(3,3), v1(3), v2(3), t1` (No comment)
+- `real(8), intent( in) :: vpl(3)` (No comment)
+- `type( k_set), intent( in) :: kset` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- mod_kpointset
+- modinput
+- modmain
+
+**Calls:**
+- r3frac
+- r3mtv

--- a/docs/src_docs/findprim.f90.md
+++ b/docs/src_docs/findprim.f90.md
@@ -1,0 +1,45 @@
+# findprim.f90
+
+## Overview
+
+  This routine finds the smallest primitive cell which produces the same
+  crystal structure as the conventional cell. This is done by searching
+  through all the vectors which connect atomic positions and finding those
+  which leave the crystal structure invariant. Of these, the three shortest
+  which produce a non-zero unit cell volume are chosen.
+
+  Created April 2007 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE findprim
+
+## Important Variables/Constants
+
+- `Integer :: i, j, n, na` (No comment)
+- `Integer :: i1, i2, i3, iv (3)` (No comment)
+- `Integer :: is, js, ia, ja, ka` (No comment)
+- `Real (8) :: apl (3, maxatoms)` (No comment)
+- `Real (8) :: r3taxi` (No comment)
+- `Real (8) :: t1, t2` (No comment)
+- `Real (8) :: v1 (3), v2 (3), v3 (3)` (No comment)
+- `Real (8), Allocatable :: distance (:)` (No comment)
+- `Real (8), Allocatable :: vp (:, :)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- r3cross
+- r3frac
+- r3minv
+- r3mv

--- a/docs/src_docs/findsym.f90.md
+++ b/docs/src_docs/findsym.f90.md
@@ -1,0 +1,50 @@
+# findsym.f90
+
+## Overview
+
+  Finds the symmetries which rotate one set of atomic positions into another.
+  Both sets of positions differ only by a translation vector and have the same
+  muffin-tin magnetic fields (stored in the global array {\tt bfcmt}). Any
+  symmetry element consists of a spatial rotation of the atomic position
+  vectors followed by a global magnetic rotation: $\{\alpha_S|\alpha_R\}$. In
+  the case of spin-orbit coupling $\alpha_S=\alpha_R$. The symmetries are
+  returned as indices of elements in the Bravais lattice point group. An
+  index to equivalent atoms is stored in the array {\tt iea}.
+
+  Created April 2007 (JKD)
+  Fixed use of proper rotations for spin, February 2008 (L. Nordstrom)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE findsym
+
+## Important Variables/Constants
+
+- `Integer :: is, ia, ja, iv (3), md` (No comment)
+- `Integer :: isym, jsym, jsym0, jsym1` (No comment)
+- `Integer :: jea (natmmax, nspecies)` (No comment)
+- `Integer, Intent (Out) :: iea (natmmax, nspecies, 48)` (No comment)
+- `Integer, Intent (Out) :: lspl (48)` (No comment)
+- `Integer, Intent (Out) :: lspn (48)` (No comment)
+- `Integer, Intent (Out) :: nsym` (No comment)
+- `Real (8) :: apl3 (3, natmmax)` (No comment)
+- `Real (8) :: r3taxi` (No comment)
+- `Real (8) :: sl (3, 3), v (3), t1` (No comment)
+- `Real (8), Intent (In) :: apl1 (3, maxatoms, maxspecies)` (No comment)
+- `Real (8), Intent (In) :: apl2 (3, maxatoms, maxspecies)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- r3frac
+- r3mv

--- a/docs/src_docs/findsymcrys.f90.md
+++ b/docs/src_docs/findsymcrys.f90.md
@@ -1,0 +1,51 @@
+# findsymcrys.f90
+
+## Overview
+
+  Finds the complete set of symmetries which leave the crystal structure
+  (including the magnetic fields) invariant. A crystal symmetry is of the
+  form $\{\alpha_S|\alpha_R|{\bf t}\}$, where ${\bf t}$ is a translation
+  vector, $\alpha_R$ is a spatial rotation operation and $\alpha_S$ is a
+  global spin rotation. Note that the order of operations is important and
+  defined to be from right to left, i.e. translation followed by spatial
+  rotation followed by spin rotation. In the case of spin-orbit coupling
+  $\alpha_S=\alpha_R$. In order to determine the translation vectors, the
+  entire atomic basis is shifted so that the first atom in the smallest set of
+  atoms of the same species is at the origin. Then all displacement vectors
+  between atoms in this set are checked as possible symmetry translations. If
+  the global variable {\tt tshift} is set to {\tt .false.} then the shift is
+  not performed. See L. M. Sandratskii and P. G. Guletskii, {\it J. Phys. F:
+  Met. Phys.} {\bf 16}, L43 (1986) and the routine {\tt findsym}.
+
+  Created April 2007 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE findsymcrys
+
+## Important Variables/Constants
+
+- `Integer :: ia, ja, is, js, i, n` (No comment)
+- `Integer :: isym, nsym, iv (3)` (No comment)
+- `Integer :: lspl (48), lspn (48)` (No comment)
+- `Integer, Allocatable :: iea (:, :, :)` (No comment)
+- `Real (8) :: v (3), t1` (No comment)
+- `Real (8), Allocatable :: vtl (:, :)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+- modxs
+
+**Calls:**
+- findsym
+- r3frac
+- r3mv

--- a/docs/src_docs/findsymlat.f90.md
+++ b/docs/src_docs/findsymlat.f90.md
@@ -1,0 +1,45 @@
+# findsymlat.f90
+
+## Overview
+
+  Finds the point group symmetries which leave the Bravais lattice invariant.
+  Let $A$ be the matrix consisting of the lattice vectors in columns, then
+  $$ g=A^{\rm T}A $$
+  is the metric tensor. Any $3\times 3$ matrix $S$ with elements $-1$, 0 or 1
+  is a point group symmetry of the lattice if $\det(S)$ is $-1$ or 1, and
+  $$ S^{\rm T}gS=g. $$
+  The first matrix in the set returned is the identity.
+
+  Created January 2003 (JKD)
+  Removed arguments and simplified, April 2007 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE findsymlat
+
+## Important Variables/Constants
+
+- `Integer :: i, j, md, sym (3, 3)` (No comment)
+- `Integer :: i11, i12, i13, i21, i22, i23, i31, i32, i33` (No comment)
+- `Integer :: i3mdet` (No comment)
+- `Real (8) :: c (3, 3), v (3), t1` (No comment)
+- `Real (8) :: r3taxi` (No comment)
+- `Real (8) :: s (3, 3), g (3, 3), sgs (3, 3)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- i3minv
+- r3mm
+- r3mtm
+- r3mtv

--- a/docs/src_docs/findsymsite.f90.md
+++ b/docs/src_docs/findsymsite.f90.md
@@ -1,0 +1,28 @@
+# findsymsite.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE findsymsite
+
+## Important Variables/Constants
+
+- `Integer :: is, js, ia, ja, ias` (No comment)
+- `Real (8) :: apl (3, maxatoms, maxspecies)` (No comment)
+- `Real (8) :: iea (natmmax, nspecies, 48)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- findsym

--- a/docs/src_docs/force.f90.md
+++ b/docs/src_docs/force.f90.md
@@ -1,0 +1,107 @@
+# force.f90
+
+## Overview
+
+  Computes the various contributions to the atomic forces. In principle, the
+  force acting on a nucleus is simply the gradient at that site of the
+  classical electrostatic potential from the other nuclei and the electronic
+  density. This is a result of the Hellmann-Feynman theorem. However because
+  the basis set is dependent on the nuclear coordinates and is not complete,
+  the Hellman-Feynman force is inacurate and corrections to it are required.
+  The first is the core correction which arises because the core wavefunctions
+  were determined by neglecting the non-spherical parts of the effective
+  potential $v_s$. Explicitly this is given by
+  $$ {\bf F}_{\rm core}^{\alpha}=\int_{\rm MT_{\alpha}} v_{\rm s}({\bf r})
+   \nabla\rho_{\rm core}^{\alpha}({\bf r})\,d{\bf r} $$
+  for atom $\alpha$. The second, which is the incomplete basis set (IBS)
+  correction, is due to the position dependence of the APW functions, and is
+  derived by considering the change in total energy if the eigenvector
+  coefficients were fixed and the APW functions themselves were changed. This
+  would result in changes to the first-variational Hamiltonian and overlap
+  matrices given by
+  \begin{align*}
+   \delta H_{\bf G,G'}^{\alpha}&=i({\bf G-G'})
+   \left(H^{\alpha}_{\bf G+k,G'+k}-\frac{1}{2}({\bf G+k})\cdot({\bf G'+k})
+   \tilde{\Theta}_{\alpha}({\bf G-G'})e^{-i({\bf G-G'})\cdot{\bf r}_{\alpha}}
+   \right)\\
+   \delta O_{\bf G,G'}^{\alpha}&=i({\bf G-G'})\left(O^{\alpha}_{\bf G+k,G'+k}
+   -\tilde{\Theta}_{\alpha}({\bf G-G'})e^{-i({\bf G-G'})\cdot{\bf r}_{\alpha}}
+   \right)
+  \end{align*}
+  where both ${\bf G}$ and ${\bf G'}$ run over the APW indices;
+  $\tilde{\Theta}_{\alpha}$ is the form factor of the smooth step function for
+  muffin-tin $\alpha$; and $H^{\alpha}$ and $O^{\alpha}$ are the muffin-tin
+  Hamiltonian and overlap matrices, respectively. The APW-local-orbital part
+  is given by
+  \begin{align*}
+   \delta H_{\bf G,G'}^{\alpha}&=i({\bf G+k})H^{\alpha}_{\bf G+k,G'+k}\\
+   \delta O_{\bf G,G'}^{\alpha}&=i({\bf G+k})O^{\alpha}_{\bf G+k,G'+k}
+  \end{align*}
+  where ${\bf G}$ runs over the APW indices and ${\bf G'}$ runs over the
+  local-orbital indices. There is no contribution from the
+  local-orbital-local-orbital part of the matrices. We can now write the IBS
+  correction in terms of the basis of first-variational states as
+  \begin{align*}
+   {\bf F}_{ij}^{\alpha{\bf k}}=\sum_{\bf G,G'}
+   b^{i{\bf k}*}_{\bf G}b^{j{\bf k}}_{\bf G'}\left(
+   \delta H_{\bf G,G'}^{\alpha}-\epsilon_j\delta O_{\bf G,G'}^{\alpha}\right),
+  \end{align*}
+  where $b^{i{\bf k}}$ is the first-variational eigenvector.
+  Finally, the ${\bf F}_{ij}^{\alpha{\bf k}}$ matrix elements can be
+  multiplied by the second-variational coefficients, and contracted over all
+  indices to obtain the IBS force:
+  \begin{align*}
+   {\bf F}_{\rm IBS}^{\alpha}=\sum_{\bf k}w_{\bf k}\sum_{l\sigma}n_{l{\bf k}}
+   \sum_{ij}c_{\sigma i}^{l{\bf k}*}c_{\sigma j}^{l{\bf k}}
+   {\bf F}_{ij}^{\alpha{\bf k}}
+   +\int_{\rm MT_{\alpha}}v_{\rm s}({\bf r})\nabla\left[\rho({\bf r})
+   -\rho^{\alpha}_{\rm core}({\bf r})\right]\,d{\bf r},
+  \end{align*}
+  where $c^{l{\bf k}}$ are the second-variational coefficients, $w_{\bf k}$
+  are the $k$-point weights, $n_{l{\bf k}}$ are the occupancies, and
+  $v_{\rm s}$ is the Kohn-Sham effective potential. See routines {\tt hmlaa},
+  {\tt olpaa}, {\tt hmlalo}, {\tt olpalo}, {\tt energy}, {\tt seceqn} and
+  {\tt gencfun}.
+
+  Created January 2004 (JKD)
+  Fixed problem with second-variational forces, May 2008 (JKD)
+  k-point parallelisation of IBS forces, October 2013 (Andris)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE force
+
+## Important Variables/Constants
+
+- `Integer :: ik, is, ia, ias, nr, i` (No comment)
+- `Real (8) :: rfmtinp` (No comment)
+- `Real (8) :: sum, t1` (No comment)
+- `Real (8) :: ts0, ts1` (No comment)
+- `Real (8), Allocatable :: ffacg (:, :)` (No comment)
+- `Real (8), Allocatable :: forcesum(:,:)` (No comment)
+- `Real (8), Allocatable :: grfmt (:, :, :)` (No comment)
+- `Real (8), Allocatable :: rfmt (:, :)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+- modmpi
+
+**Calls:**
+- DFT_D2_force
+- MPI_ALLREDUCE
+- TS_vdW_force
+- forcek
+- genffacg
+- gradrfmt
+- olprad
+- symvect
+- timesec

--- a/docs/src_docs/forcek.f90.md
+++ b/docs/src_docs/forcek.f90.md
@@ -1,0 +1,60 @@
+# forcek.f90
+
+## Overview
+
+  Computes the {\bf k}-dependent contribution to the incomplete basis set
+  (IBS) force. See the calling routine {\tt force} for a full description.
+
+  Created June 2006 (JKD)
+  Updated for spin-spiral case, May 2007 (Francesco Cricchio and JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE forcek
+
+## Important Variables/Constants
+
+- `Complex (8), Allocatable :: apwalm (:, :, :, :)` (No comment)
+- `Complex (8), Allocatable :: apwi(:,:),zm(:,:),apwi2(:,:)` (No comment)
+- `Complex (8), Allocatable :: dlhij(:,:)` (No comment)
+- `Complex (8), Allocatable :: dloij(:,:)` (No comment)
+- `Complex (8), Allocatable :: evecfv (:, :, :),evecfv2(:,:,:)` (No comment)
+- `Complex (8), Allocatable :: evecsv (:, :)` (No comment)
+- `Complex (8), Allocatable :: ffv (:, :)` (No comment)
+- `Complex (8), Allocatable :: y (:)` (No comment)
+- `Integer :: i, j, k, l, iv (3), ig` (No comment)
+- `Integer :: is, ia, ias, ist, jst` (No comment)
+- `Integer :: np, ispn, jspn` (No comment)
+- `Integer, Allocatable :: ijgij(:,:)` (No comment)
+- `Integer, Intent (In) :: ik` (No comment)
+- `Real (8) :: sum, t1, ta,tb` (No comment)
+- `Real (8), Allocatable :: dpij(:,:)` (No comment)
+- `Real (8), Allocatable :: evalfv (:, :)` (No comment)
+- `Real (8), Intent (In) :: ffacg (ngvec, nspecies)` (No comment)
+- `Type (evsystem) :: system` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- mod_eigensystem
+- modfvsystem
+- modinput
+- modmain
+
+**Calls:**
+- deletesystem
+- getevalfv
+- getevecfv
+- getevecsv
+- getoccsv
+- match
+- newsystem
+- zgemm
+- zgemv

--- a/docs/src_docs/fsmfield.f90.md
+++ b/docs/src_docs/fsmfield.f90.md
@@ -1,0 +1,38 @@
+# fsmfield.f90
+
+## Overview
+
+  Updates the effective magnetic field, ${\bf B}_{\rm FSM}$, required for
+  fixing the spin moment to a given value, $\boldsymbol{\mu}_{\rm FSM}$. This
+  is done by adding a vector to the field which is proportional to the
+  difference between the moment calculated in the $i$th self-consistent loop
+  and the required moment:
+  $$ {\bf B}_{\rm FSM}^{i+1}={\bf B}_{\rm FSM}^i+\lambda\left(
+   \boldsymbol{\mu}^i-\boldsymbol{\mu}_{\rm FSM}\right), $$
+  where $\lambda$ is a scaling factor.
+
+  Created March 2005 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE fsmfield
+
+## Important Variables/Constants
+
+- `Integer :: is, ia, ias, ir, idm` (No comment)
+- `Real (8) :: v (3), t1` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- *None identified.*

--- a/docs/src_docs/gdft.f90.md
+++ b/docs/src_docs/gdft.f90.md
@@ -1,0 +1,45 @@
+# gdft.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE gdft
+
+## Important Variables/Constants
+
+- `Complex (8), Allocatable :: apwalm (:, :, :, :)` (No comment)
+- `Complex (8), Allocatable :: evecfv (:, :)` (No comment)
+- `Complex (8), Allocatable :: evecsv (:, :)` (No comment)
+- `Complex (8), Allocatable :: wfir (:, :, :)` (No comment)
+- `Complex (8), Allocatable :: wfmt (:, :, :, :, :)` (No comment)
+- `Integer :: ir, irc, itp` (No comment)
+- `Integer :: ist, jst, is, ia, ias` (No comment)
+- `Integer, Intent (In) :: ik` (No comment)
+- `Real (8) :: fr (nrcmtmax), gr (nrcmtmax), cf (3, nrcmtmax)` (No comment)
+- `Real (8) :: rflm (lmmaxvr), rftp (lmmaxvr)` (No comment)
+- `Real (8) :: sum, t1, t2` (No comment)
+- `Real (8), Allocatable :: rfir (:)` (No comment)
+- `Real (8), Allocatable :: rfmt (:, :, :)` (No comment)
+- `Real (8), Intent (Out) :: delta (nstsv, nstsv)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- modinput
+- modmain
+
+**Calls:**
+- dgemv
+- fderiv
+- genwfsv
+- getevecfv
+- getevecsv
+- match

--- a/docs/src_docs/genapwfr.f90.md
+++ b/docs/src_docs/genapwfr.f90.md
@@ -1,0 +1,43 @@
+# genapwfr.f90
+
+## Overview
+
+  Generates the APW radial functions. This is done by integrating the scalar
+  relativistic Schr\"{o}dinger equation (or its energy deriatives) at the
+  current linearisation energies using the spherical part of the effective
+  potential. The number of radial functions at each $l$-value is given by the
+  variable {\tt apword} (at the muffin-tin boundary, the APW functions have
+  continuous derivatives up to order ${\tt apword}-1$). Within each $l$, these
+  functions are orthonormalised with the Gram-Schmidt method. The radial
+  Hamiltonian is applied to the orthonormalised functions and the results are
+  stored in the global array {\tt apwfr}.
+
+  Created March 2003 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE genapwfr
+
+## Important Variables/Constants
+
+- `Integer :: is, ia, ias, nr, ir` (No comment)
+- `Integer :: nn, l, io1, io2` (No comment)
+- `Real (8) :: hp0 (nrmtmax)` (No comment)
+- `Real (8) :: q0 (nrmtmax, apwordmax), q1 (nrmtmax, apwordmax)` (No comment)
+- `Real (8) :: t1` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- fderiv
+- rschroddme

--- a/docs/src_docs/genbmatk.f90.md
+++ b/docs/src_docs/genbmatk.f90.md
@@ -1,0 +1,35 @@
+# genbmatk.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE genbmatk
+
+## Important Variables/Constants
+
+- `Complex (8), Allocatable :: zfir (:, :)` (No comment)
+- `Complex (8), Allocatable :: zfmt (:, :, :)` (No comment)
+- `Complex (8), Intent (In) :: wfir (ngrtot, nspinor, nstsv)` (No comment)
+- `Complex (8), Intent (Out) :: bmat (nstsv, nstsv)` (No comment)
+- `Integer :: is, ia, ias, nrc, ir, irc` (No comment)
+- `Integer :: ist, jst, idm, ispn` (No comment)
+- `Real (8) :: t1` (No comment)
+- `Real (8), Allocatable :: rvfir (:, :)` (No comment)
+- `Real (8), Intent (In) :: bir (ngrtot, ndmag)` (No comment)
+- `Real (8), Intent (In) :: bmt (lmmaxvr, nrcmtmax, natmtot, ndmag)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- *None identified.*

--- a/docs/src_docs/gencfun.f90.md
+++ b/docs/src_docs/gencfun.f90.md
@@ -1,0 +1,46 @@
+# gencfun.f90
+
+## Overview
+
+  Generates the smooth characteristic function. This is the function which is
+  0 within the muffin-tins and 1 in the intersitial region and is constructed
+  from radial step function form-factors with $G<G_{\rm max}$. The form
+  factors are given by
+  $$ \tilde{\Theta}_i(G)=\begin{cases}
+   \frac{4\pi R_i^3}{3 \Omega} & G=0 \\
+   \frac{4\pi R_i^3}{\Omega}\frac{j_1(GR_i)}{GR_i} & 0<G\le G_{\rm max} \\
+   0 & G>G_{\rm max}\end{cases}, $$
+  where $R_i$ is the muffin-tin radius of the $i$th species and $\Omega$ is
+  the unit cell volume. Therefore the characteristic function in $G$-space is
+  $$ \tilde{\Theta}({\bf G})=\delta_{G,0}-\sum_{ij}\exp(-i{\bf G}\cdot
+   {\bf r}_{ij})\tilde{\Theta}_i(G), $$
+  where ${\bf r}_{ij}$ is the position of the $j$th atom of the $i$th species.
+
+  Created January 2003 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE gencfun
+
+## Important Variables/Constants
+
+- `Complex (8), Allocatable :: zfft (:)` (No comment)
+- `Integer :: is, ia, ig, ifg` (No comment)
+- `Real (8) :: t1, t2` (No comment)
+- `Real (8), Allocatable :: ffacg (:)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- modinput
+- modmain
+
+**Calls:**
+- zfftifc

--- a/docs/src_docs/gencore.f90.md
+++ b/docs/src_docs/gencore.f90.md
@@ -1,0 +1,42 @@
+# gencore.f90
+
+## Overview
+
+  Computes the core radial wavefunctions, eigenvalues and densities. The
+  radial Dirac equation is solved in the spherical part of the effective
+  potential to which the atomic potential has been appended for
+  $r>R^{\rm MT}$. In the case of spin-polarised calculations, the effective
+  magnetic field is ignored.
+
+  Created April 2003 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE gencore
+
+## Important Variables/Constants
+
+- `Integer :: is, ia, ja, ias, jas, ist, ir` (No comment)
+- `Logical :: done (natmmax)` (No comment)
+- `Real (8) :: t1` (No comment)
+- `Real (8) :: vr (spnrmax)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- mod_atoms
+- mod_corestate
+- mod_muffin_tin
+- mod_potential_and_density
+- mod_symmetry
+- modinput
+
+**Calls:**
+- rdirac

--- a/docs/src_docs/gendmat.f90.md
+++ b/docs/src_docs/gendmat.f90.md
@@ -1,0 +1,46 @@
+# gendmat.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE gendmat
+
+## Important Variables/Constants
+
+- `Complex (8), Allocatable :: wfmt1 (:, :, :, :)` (No comment)
+- `Complex (8), Allocatable :: wfmt2 (:, :, :)` (No comment)
+- `Complex (8), Intent (In) :: evecfv (nmatmax, nstfv, nspnfv)` (No comment)
+- `Complex (8), Intent (In) :: evecsv (nstsv, nstsv)` (No comment)
+- `Integer :: i, j, n, ist, irc` (No comment)
+- `Integer :: ispn, jspn, lmmax` (No comment)
+- `Integer :: l, m1, m2, lm1, lm2` (No comment)
+- `Integer, Intent (In) :: ia` (No comment)
+- `Integer, Intent (In) :: is` (No comment)
+- `Integer, Intent (In) :: ld` (No comment)
+- `Integer, Intent (In) :: lmax` (No comment)
+- `Integer, Intent (In) :: lmin` (No comment)
+- `Integer, Intent (In) :: ngp (nspnfv)` (No comment)
+- `Logical, Allocatable :: done (:, :)` (No comment)
+- `Logical, Intent (In) :: tlmdg` (No comment)
+- `Logical, Intent (In) :: tspndg` (No comment)
+- `Real (8) :: fr1 (nrcmtmax), fr2 (nrcmtmax)` (No comment)
+- `Real (8) :: gr (nrcmtmax), cf (3, nrcmtmax)` (No comment)
+- `Real (8) :: t1, t2` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- fderiv
+- wavefmt
+- zaxpy

--- a/docs/src_docs/gendmat_nospin.f90.md
+++ b/docs/src_docs/gendmat_nospin.f90.md
@@ -1,0 +1,42 @@
+# gendmat_nospin.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE gendmat_nospin
+
+## Important Variables/Constants
+
+- `Complex (8), Allocatable :: wfmt2 (:, :, :)` (No comment)
+- `Complex (8), Intent (In) :: apwalm( ngkmax, apwordmax, lmmaxapw, natmtot, nspnfv)` (No comment)
+- `Complex (8), Intent (In) :: evecfv( nmatmax, fst:lst, nspnfv)` (No comment)
+- `Complex (8), Intent (Out) :: dmat( ld, ld, fst:lst)` (No comment)
+- `Integer :: i, j, n, ist, irc` (No comment)
+- `Integer :: l, m1, m2, lm1, lm2` (No comment)
+- `Integer :: lmmax` (No comment)
+- `Integer, Intent (In) :: ia` (No comment)
+- `Integer, Intent (In) :: is` (No comment)
+- `Integer, Intent (In) :: ld` (No comment)
+- `Integer, Intent (In) :: lmax` (No comment)
+- `Integer, Intent (In) :: lmin, fst, lst` (No comment)
+- `Integer, Intent (In) :: ngp` (No comment)
+- `Real (8) :: fr1 (nrcmtmax), fr2 (nrcmtmax)` (No comment)
+- `Real (8) :: gr (nrcmtmax), cf (3, nrcmtmax)` (No comment)
+- `Real (8) :: t1, t2` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- fderiv
+- wavefmt

--- a/docs/src_docs/gendmatmt.f90.md
+++ b/docs/src_docs/gendmatmt.f90.md
@@ -1,0 +1,47 @@
+# gendmatmt.f90
+
+## Overview
+
+  Constructs a contribution to the density matrix  due to the $\mathbf{k}$-point ik.
+
+  Created May 2014 (Andris)
+  Revised Aug 2020 (Ronaldo)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE gendmatmt
+
+## Important Variables/Constants
+
+- `Complex (8), Allocatable :: apwalm (:, :, :, :, :),apwi(:,:)` (No comment)
+- `Complex (8), Allocatable :: dm2(:,:)` (No comment)
+- `Complex (8), Intent (In) :: evecfv (nmatmax, nstfv, nspnfv)` (No comment)
+- `Complex (8), Intent (In) :: evecsv (nstsv, nstsv)` (No comment)
+- `Complex (8), pointer :: wf1(:,:), wf2prime(:,:), wfalpha(:,:),wfbeta(:,:)` (No comment)
+- `Integer :: i, n, maxaa, maxnlo, wfsize` (No comment)
+- `Integer :: ispn, is, ia, ias` (No comment)
+- `Integer :: l, m, lm, io` (No comment)
+- `Integer, Intent (In) :: ik` (No comment)
+- `Real (8) :: t1, t2` (No comment)
+- `Real (8) :: ts0, ts1` (No comment)
+- `integer , pointer :: losize(:)` (No comment)
+- `integer :: l3,lm3,if3,ngp,l1,lm1,j1,j3` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- modinput
+- modmain
+- modmpi
+
+**Calls:**
+- match
+- timesec
+- zgemm

--- a/docs/src_docs/genexpiqr.f90.md
+++ b/docs/src_docs/genexpiqr.f90.md
@@ -1,0 +1,69 @@
+# genexpiqr.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE genexpiqr
+
+## Important Variables/Constants
+
+- `Complex (8), Allocatable :: apwalm1 (:, :, :, :)` (No comment)
+- `Complex (8), Allocatable :: apwalm2 (:, :, :, :)` (No comment)
+- `Complex (8), Allocatable :: em (:, :)` (No comment)
+- `Complex (8), Allocatable :: evecfv1 (:, :)` (No comment)
+- `Complex (8), Allocatable :: evecfv2 (:, :)` (No comment)
+- `Complex (8), Allocatable :: evecsv1 (:, :)` (No comment)
+- `Complex (8), Allocatable :: evecsv2 (:, :)` (No comment)
+- `Complex (8), Allocatable :: sfacgkq (:, :)` (No comment)
+- `Complex (8), Allocatable :: wfir (:)` (No comment)
+- `Complex (8), Allocatable :: wfmt1 (:, :)` (No comment)
+- `Complex (8), Allocatable :: wfmt2 (:, :, :)` (No comment)
+- `Complex (8), Allocatable :: wfmt3 (:, :)` (No comment)
+- `Complex (8), Allocatable :: zfir1 (:)` (No comment)
+- `Complex (8), Allocatable :: zfir2 (:)` (No comment)
+- `Complex (8), Intent (Out) :: emat (nstsv, nstsv)` (No comment)
+- `Integer :: i, j, k, l, ispn` (No comment)
+- `Integer :: is, ia, i1, i2, i3, iv (3)` (No comment)
+- `Integer :: l1, l2, l3, m1, m2, m3` (No comment)
+- `Integer :: lm1, lm2, lm3, ist, jst` (No comment)
+- `Integer :: ngkq, igk, ifg, ir, irc` (No comment)
+- `Integer, Allocatable :: igkqig (:)` (No comment)
+- `Integer, Intent (In) :: ik` (No comment)
+- `Real (8) :: gaunt` (No comment)
+- `Real (8) :: v1 (3), v2 (3), v3 (3)` (No comment)
+- `Real (8) :: vecqc (3), qc, tp (2)` (No comment)
+- `Real (8) :: vkql (3), vkqc (3), x, t1` (No comment)
+- `Real (8), Allocatable :: gkqc (:)` (No comment)
+- `Real (8), Allocatable :: gnt (:, :, :)` (No comment)
+- `Real (8), Allocatable :: jlqr (:, :)` (No comment)
+- `Real (8), Allocatable :: tpgkqc (:, :)` (No comment)
+- `Real (8), Allocatable :: vgkqc (:, :)` (No comment)
+- `Real (8), Allocatable :: vgkql (:, :)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- modinput
+- modmain
+
+**Calls:**
+- gengpvec
+- gensfacgp
+- genylm
+- getevecfv
+- getevecsv
+- match
+- r3frac
+- r3mv
+- sbessel
+- sphcrd
+- wavefmt
+- zfftifc

--- a/docs/src_docs/genffacg.f90.md
+++ b/docs/src_docs/genffacg.f90.md
@@ -1,0 +1,30 @@
+# genffacg.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE genffacg
+
+## Important Variables/Constants
+
+- `Integer :: ig` (No comment)
+- `Integer, Intent (In) :: is` (No comment)
+- `Real (8) :: t1, t2, t3, t4` (No comment)
+- `Real (8), Intent (Out) :: ffacg (ngvec)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- modinput
+- modmain
+
+**Calls:**
+- *None identified.*

--- a/docs/src_docs/genlofr.f90.md
+++ b/docs/src_docs/genlofr.f90.md
@@ -1,0 +1,51 @@
+# genlofr.f90
+
+## Overview
+
+  Generates the local-orbital radial functions. This is done by integrating
+  the scalar relativistic Schr\"{o}dinger equation (or its energy deriatives)
+  at the current linearisation energies using the spherical part of the
+  effective potential. For each local-orbital, a linear combination of
+  {\tt lorbord} radial functions is constructed such that its radial
+  derivatives up to order ${\tt lorbord}-1$ are zero at the muffin-tin radius.
+  This function is normalised and the radial Hamiltonian applied to it. The
+  results are stored in the global array {\tt lofr}.
+
+  Created March 2003 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE genlofr
+
+## Important Variables/Constants
+
+- `Integer :: ilo, io1, io2` (No comment)
+- `Integer :: is, ia, ias, nr, ir` (No comment)
+- `Integer :: j, l, nn, info, np` (No comment)
+- `Integer, Allocatable :: ipiv (:)` (No comment)
+- `Real (8) :: hp0 (nrmtmax)` (No comment)
+- `Real (8) :: p0 (nrmtmax, maxlorbord), p1 (nrmtmax,maxlorbord)` (No comment)
+- `Real (8) :: p0s (nrmtmax), p1s (nrmtmax) ,q0s (nrmtmax), q1s (nrmtmax)` (No comment)
+- `Real (8) :: polynom` (No comment)
+- `Real (8) :: q0 (nrmtmax, maxlorbord), q1 (nrmtmax, maxlorbord)` (No comment)
+- `Real (8) :: t1` (No comment)
+- `Real (8), Allocatable :: a (:, :), b (:), c (:)` (No comment)
+- `Real (8), Allocatable :: xa (:), ya (:)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- dgesv
+- fderiv
+- rdirac
+- rschroddme

--- a/docs/src_docs/genrhoir.f90.md
+++ b/docs/src_docs/genrhoir.f90.md
@@ -1,0 +1,50 @@
+# genrhoir.f90
+
+## Overview
+
+  Generates the partial valence charge density from the eigenvectors at
+  $k$-point {\tt ik}. In the muffin-tin region, the wavefunction is obtained
+  in terms of its $(l,m)$-components from both the APW and local-orbital
+  functions. Using a backward spherical harmonic transform (SHT), the
+  wavefunction is converted to real-space and the density obtained from its
+  modulus squared. This density is then transformed with a forward SHT and
+  accumulated in the global variable {\tt rhomt}. A similar proccess is used
+  for the intersitial density in which the wavefunction in real-space is
+  obtained from a Fourier transform of the sum of APW functions. The
+  interstitial density is added to the global array {\tt rhoir}. See routines
+  {\tt wavefmt}, {\tt genshtmat} and {\tt seceqn}.
+
+  Created April 2003 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE genrhoir
+
+## Important Variables/Constants
+
+- `Complex (8), Allocatable :: zfft (:, :)` (No comment)
+- `Complex (8), Intent (In) :: evecfv (nmatmax, nstfv, nspnfv)` (No comment)
+- `Complex (8), Intent (In) :: evecsv (nstsv, nstsv)` (No comment)
+- `Integer :: ir, irc, itp, igk, ifg, i, j, n` (No comment)
+- `Integer :: nsd, ispn, jspn, is, ia, ias, ist` (No comment)
+- `Integer, Intent (In) :: ik` (No comment)
+- `Real (8) :: magir_k (ngrtot, ndmag)` (No comment)
+- `Real (8) :: rhoir_k (ngrtot)` (No comment)
+- `Real (8) :: t1, t2, t3, t4` (No comment)
+- `Real (8) :: ts0, ts1` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- timesec
+- zfftifc

--- a/docs/src_docs/genrhomt.f90.md
+++ b/docs/src_docs/genrhomt.f90.md
@@ -1,0 +1,42 @@
+# genrhomt.f90
+
+## Overview
+
+  Generates the muffin tin part of the charge density from the density matrix.
+
+  Created May 2014 (Andris)
+  Revised Aug 2020 (Ronaldo)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE genrhomt
+
+## Important Variables/Constants
+
+- `Real (8) :: t1, t2` (No comment)
+- `Real (8) :: ts0, ts1` (No comment)
+- `integer :: i, n` (No comment)
+- `integer :: ilo1,ilo2,maxnlo,maxaa,wfsize` (No comment)
+- `integer :: is, ia, ias` (No comment)
+- `integer :: l3,lm3,m3,io1,io2,if1,if3,l1,m1,lm1,lm2,if3old,if1old` (No comment)
+- `integer, pointer :: losize(:)` (No comment)
+- `real(8) :: alpha,a` (No comment)
+- `real(8), allocatable :: factors(:),rho(:,:,:),factorsnew(:,:),frnew(:,:)` (No comment)
+- `real(8), intent(out) :: densitymt(lmmaxvr,nrmtmax,natmtot)` (No comment)
+- `type(apw_lo_basis_type), intent(in) :: basis1, basis2` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+- modmpi
+
+**Calls:**
+- timesec

--- a/docs/src_docs/linengy.f90.md
+++ b/docs/src_docs/linengy.f90.md
@@ -1,0 +1,43 @@
+# linengy.f90
+
+## Overview
+
+  Calculates the new linearisation energies for both the APW and local-orbital
+  radial functions. See the routine {\tt findband}.
+
+  Created May 2003 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE linengy
+
+## Important Variables/Constants
+
+- `Integer :: is, ia, ja, ias, jas` (No comment)
+- `Integer :: l, ilo, io1, io2` (No comment)
+- `Logical :: done (natmmax)` (No comment)
+- `Real (8) :: vr (nrmtmax)` (No comment)
+- `character(1024) :: message` (No comment)
+- `character(256) :: linenetype, fname` (No comment)
+- `integer :: nr, nn` (No comment)
+- `logical :: tfnd` (No comment)
+- `real(8) :: t0, t1, e, dl` (No comment)
+- `real(8), allocatable :: p0 (:), p1 (:), q0 (:), q1 (:)` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+- scl_xml_out_Module
+
+**Calls:**
+- findband
+- rschroddme
+- warning

--- a/docs/src_docs/occupy.f90.md
+++ b/docs/src_docs/occupy.f90.md
@@ -1,0 +1,56 @@
+# occupy.f90
+
+## Overview
+
+  Finds the Fermi energy and sets the occupation numbers for the
+  second-variational states using the routine {\tt fermi}.
+
+  Created February 2004 (JKD)
+  Modifiactions for tetrahedron method, November 2007 (RGA alias
+    Ricardo Gomez-Abal)
+  Modifications for tetrahedron method, 2007-2010 (Sagmeister)
+  Modifications for tetrahedron method, 2011 (DIN)
+  Simplicistic method for systems with gap added, 2013 (STK)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE occupy
+
+## Important Variables/Constants
+
+- `character(1024) :: message` (No comment)
+- `integer :: ik, ist, it, nvm` (No comment)
+- `integer, parameter :: maxit = 1000` (No comment)
+- `logical :: lspin` (No comment)
+- `real(8) :: dfde(nstsv,nkpt)` (No comment)
+- `real(8) :: e0, e1, chg, x, t1` (No comment)
+- `real(8) :: egap` (No comment)
+- `real(8) :: sdelta, stheta` (No comment)
+- `real(8), parameter :: de0=1.d0` (No comment)
+- `type( k_set) :: kset` (No comment)
+- `type( t_set) :: tetra` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- mod_kpointset
+- mod_opt_tetra
+- modinput
+- modmain
+
+**Calls:**
+- delete_k_vectors
+- fermi_exciting
+- generate_k_vectors
+- opt_tetra_destroy
+- opt_tetra_efermi
+- opt_tetra_init
+- opt_tetra_wgt_delta
+- tetiw
+- warning

--- a/docs/src_docs/physical_constants.f90.md
+++ b/docs/src_docs/physical_constants.f90.md
@@ -1,0 +1,26 @@
+# physical_constants.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- MODULE physical_constants
+
+## Important Variables/Constants
+
+*No important variables or constants identified.*
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- precision
+
+**Calls:**
+- *None identified.*

--- a/docs/src_docs/plot1d.f90.md
+++ b/docs/src_docs/plot1d.f90.md
@@ -1,0 +1,56 @@
+# plot1d.f90
+
+## Overview
+
+  Produces a 1D plot of the real functions contained in arrays {\tt rfmt} and
+  {\tt rfir} along the lines connecting the vertices in the global array
+  {\tt vvlp1d}. See routine {\tt rfarray}.
+
+  Created June 2003 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE plot1d
+
+## Important Variables/Constants
+
+- `Character (128) :: buffer, buffer1` (No comment)
+- `Integer :: i, ip, iv` (No comment)
+- `Integer, Intent (In) :: ld` (No comment)
+- `Integer, Intent (In) :: lmax` (No comment)
+- `Integer, Intent (In) :: nf` (No comment)
+- `Real (8) :: fmin, fmax, t1` (No comment)
+- `Real (8), Allocatable :: fp (:, :)` (No comment)
+- `Real (8), Intent (In) :: rfir (ngrtot, nf)` (No comment)
+- `Real (8), Intent (In) :: rfmt (ld, nrmtmax, natmtot, nf)` (No comment)
+- `Type (plot1d_type) :: plotdef` (No comment)
+- `Type (xmlf_t), Save :: xf` (No comment)
+- `type(plotlabels), Intent (In) :: labels` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- FoX_wxml
+- mod_Gvector
+- mod_atoms
+- mod_muffin_tin
+- mod_plotting
+- modinput
+- modmpi
+- modplotlabels
+
+**Calls:**
+- connect
+- rfarray
+- xml_AddAttribute
+- xml_AddCharacters
+- xml_NewElement
+- xml_OpenFile
+- xml_close
+- xml_endElement

--- a/docs/src_docs/plot2d.f90.md
+++ b/docs/src_docs/plot2d.f90.md
@@ -1,0 +1,58 @@
+# plot2d.f90
+
+## Overview
+
+  Produces a 2D plot of the real functions contained in arrays {\tt rfmt} and
+  {\tt rfir} on the parallelogram defined by the corner vertices in the global
+  array {\tt vclp2d}. See routine {\tt rfarray}.
+
+  Created June 2003 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE plot2d
+
+## Important Variables/Constants
+
+- `Character (128) :: buffer, buffer1` (No comment)
+- `Integer :: i, ip, ip1, ip2` (No comment)
+- `Integer, Intent (In) :: ld` (No comment)
+- `Integer, Intent (In) :: lmax` (No comment)
+- `Integer, Intent (In) :: nf` (No comment)
+- `Real (8) :: d1, d2, d12, t1, t2, t3, t4` (No comment)
+- `Real (8) :: vl1 (3), vl2 (3), vc1 (3), vc2 (3),delta(3)` (No comment)
+- `Real (8), Allocatable :: fp (:, :)` (No comment)
+- `Real (8), Allocatable :: vpl (:, :)` (No comment)
+- `Real (8), Intent (In) :: rfir (ngrtot, nf)` (No comment)
+- `Real (8), Intent (In) :: rfmt (ld, nrmtmax, natmtot, nf)` (No comment)
+- `Type (plot2d_type) :: plotdef` (No comment)
+- `Type (xmlf_t), Save :: xf` (No comment)
+- `character (20) :: buffer20` (No comment)
+- `type(plotlabels), Intent (In) :: labels` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- FoX_wxml
+- mod_Gvector
+- mod_atoms
+- mod_muffin_tin
+- mod_plotting
+- modinput
+- modmpi
+- modplotlabels
+
+**Calls:**
+- rfarray
+- xml_AddAttribute
+- xml_AddCharacters
+- xml_Close
+- xml_NewElement
+- xml_OpenFile
+- xml_endElement

--- a/docs/src_docs/plot3d.f90.md
+++ b/docs/src_docs/plot3d.f90.md
@@ -1,0 +1,78 @@
+# plot3d.f90
+
+## Overview
+
+  Produces a 3D plot of the real functions contained in arrays {\tt rfmt} and
+  {\tt rfir} in the parallelepiped defined by the corner vertices in the
+  global array {\tt vclp3d}. See routine {\tt rfarray}.
+
+  Created June 2003 (JKD)
+  Modified, October 2008 (F. Bultmark, F. Cricchio, L. Nordstrom)
+  Modified, February 2011 (DIN)
+  Fixed a bug in gengrid, February 2014 (DIN)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE gengrid
+- SUBROUTINE plot3d
+
+## Important Variables/Constants
+
+- `Character (20) :: buffer20` (No comment)
+- `Character (512) :: buffer` (No comment)
+- `Integer :: i1, i2, i3, ip, jp` (No comment)
+- `Integer :: isym, lspl` (No comment)
+- `Integer :: np, ip1, ip2, ip3, i, ifunction, ip` (No comment)
+- `Integer,  Allocatable :: ipmap (:,:,:)` (No comment)
+- `Integer, Intent (In)  :: ngridp(3)` (No comment)
+- `Integer, Intent (In) :: ld` (No comment)
+- `Integer, Intent (In) :: lmax` (No comment)
+- `Integer, Intent (In) :: nf` (No comment)
+- `Integer, Intent (Out) :: ipmap(0:ngridp(1), 0:ngridp(2), 0:ngridp(3))` (No comment)
+- `Integer, Intent (Out) :: npt` (No comment)
+- `Real (8) :: boxl(3,4)` (No comment)
+- `Real (8) :: tmpv(3)` (No comment)
+- `Real (8) :: v1(3), v2(3), v3(3), t1, t2, t3` (No comment)
+- `Real (8), Allocatable :: fp (:, :)` (No comment)
+- `Real (8), Allocatable :: vpl (:,:)` (No comment)
+- `Real (8), Intent (In) :: rfir (ngrtot, nf)` (No comment)
+- `Real (8), Intent (In) :: rfmt (ld, nrmtmax, natmtot, nf)` (No comment)
+- `Real (8), Intent (Out) :: vpl(3,(ngridp(1)+1)*(ngridp(2)+1)*(ngridp(3)+1))` (No comment)
+- `Real(8) :: r1(3), r2(3), r3(3), vpl_(3)` (No comment)
+- `Real(8) :: s(3,3), t1` (No comment)
+- `Type (plot3d_type), Intent (In) :: plotdef` (No comment)
+- `Type (xmlf_t), Save :: xf` (No comment)
+- `integer :: iv(3)` (No comment)
+- `real(8), intent(in) :: b(3,4)` (No comment)
+- `type(plotlabels), Intent (In) :: plotlabels3d` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- FoX_wxml
+- mod_Gvector
+- mod_atoms
+- mod_muffin_tin
+- modinput
+- modmain
+- modmpi
+- modplotlabels
+
+**Calls:**
+- DGEMV
+- gengrid
+- r3frac
+- r3mv
+- rfarray
+- xml_AddAttribute
+- xml_AddCharacters
+- xml_Close
+- xml_NewElement
+- xml_OpenFile
+- xml_endElement

--- a/docs/src_docs/precision.f90.md
+++ b/docs/src_docs/precision.f90.md
@@ -1,0 +1,25 @@
+# precision.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- MODULE precision
+
+## Important Variables/Constants
+
+*No important variables or constants identified.*
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- *None identified.*
+
+**Calls:**
+- *None identified.*

--- a/docs/src_docs/readkpts.f90.md
+++ b/docs/src_docs/readkpts.f90.md
@@ -1,0 +1,32 @@
+# readkpts.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE readkpts
+
+## Important Variables/Constants
+
+- `Integer :: ik, iq, ix, iy, iz, d2` (No comment)
+- `integer :: nk` (No comment)
+- `logical :: xfastest` (No comment)
+- `real(8) :: d1` (No comment)
+- `real(8) :: vk( 3, nkpt), v1(3), v2(3)` (No comment)
+- `type( k_set) :: ksettmp` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- mod_kpointset
+- modmain
+
+**Calls:**
+- generate_k_vectors
+- init1

--- a/docs/src_docs/readstate.f90.md
+++ b/docs/src_docs/readstate.f90.md
@@ -1,0 +1,59 @@
+# readstate.f90
+
+## Overview
+
+  Reads in the charge density and other relevant variables from the file
+  {\tt STATE.OUT}. Checks for version and parameter compatibility.
+
+  Created May 2003 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE readstate
+
+## Important Variables/Constants
+
+- `Character(40) :: githash_` (No comment)
+- `Complex (8), Allocatable :: veffig_ (:)` (No comment)
+- `Complex (8), Allocatable :: vmatlu_ (:, :, :, :, :)` (No comment)
+- `Integer :: idm, ngm, i1, i2, i3, j1, j2, j3` (No comment)
+- `Integer :: iostat` (No comment)
+- `Integer :: is, ia, ias, lmmax, lm, ir, jr` (No comment)
+- `Integer :: natoms_, nrmt_ (maxspecies), nrmtmax_` (No comment)
+- `Integer :: ngrid_ (3), ngrtot_, ngvec_, ndmag_` (No comment)
+- `Integer :: nspinor_, ldapu_, lmmaxlu_` (No comment)
+- `Integer :: version_ (3), nspecies_, lmmaxvr_` (No comment)
+- `Integer, Allocatable :: mapir (:)` (No comment)
+- `Logical :: spinpol_` (No comment)
+- `Real (8) :: t1` (No comment)
+- `Real (8), Allocatable :: bxcir_ (:, :)` (No comment)
+- `Real (8), Allocatable :: bxcmt_ (:, :, :, :)` (No comment)
+- `Real (8), Allocatable :: magir_ (:, :)` (No comment)
+- `Real (8), Allocatable :: magmt_ (:, :, :, :)` (No comment)
+- `Real (8), Allocatable :: rhoir_ (:)` (No comment)
+- `Real (8), Allocatable :: rhomt_ (:, :, :)` (No comment)
+- `Real (8), Allocatable :: spr_ (:, :)` (No comment)
+- `Real (8), Allocatable :: vclir_ (:)` (No comment)
+- `Real (8), Allocatable :: vclmt_ (:, :, :)` (No comment)
+- `Real (8), Allocatable :: veffir_ (:)` (No comment)
+- `Real (8), Allocatable :: veffmt_ (:, :, :)` (No comment)
+- `Real (8), Allocatable :: vxcir_ (:)` (No comment)
+- `Real (8), Allocatable :: vxcmt_ (:, :, :)` (No comment)
+- `character(1024) :: message` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+- modxs
+
+**Calls:**
+- rfinterp
+- warning

--- a/docs/src_docs/relax.f90.md
+++ b/docs/src_docs/relax.f90.md
@@ -1,0 +1,51 @@
+# relax.f90
+
+## Overview
+
+  Created February 2013 (DIN)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE relax
+- SUBROUTINE writeoptminitdata
+
+## Important Variables/Constants
+
+- `Logical :: exist` (No comment)
+- `character(10) :: acoord` (No comment)
+- `integer :: is, ia, idm` (No comment)
+- `integer :: is, ia` (No comment)
+- `integer, intent(in) :: fnum` (No comment)
+- `integer, intent(in) :: verbosity` (No comment)
+- `real(8) :: ts0, ts1` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+- modmpi
+- scl_xml_out_Module
+
+**Calls:**
+- flushifc
+- harmonic
+- lbfgs_driver
+- newton
+- printbox
+- printline
+- printtext
+- scl_iter_xmlout
+- scl_xml_out_write
+- timesec
+- writechg
+- writeengy
+- writeforce
+- writeoptminitdata
+- writepositions

--- a/docs/src_docs/trace.F90.md
+++ b/docs/src_docs/trace.F90.md
@@ -1,0 +1,28 @@
+# trace.F90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- MODULE trace
+- SUBROUTINE trace_back
+
+## Important Variables/Constants
+
+- `character(len=*), optional, intent(in) :: error_message` (No comment)
+- `character(len=256) :: message` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- ifcore
+
+**Calls:**
+- backtrace
+- tracebackqq

--- a/docs/src_docs/unit_conversion.f90.md
+++ b/docs/src_docs/unit_conversion.f90.md
@@ -1,0 +1,25 @@
+# unit_conversion.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- MODULE unit_conversion
+
+## Important Variables/Constants
+
+*No important variables or constants identified.*
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- precision
+
+**Calls:**
+- *None identified.*

--- a/docs/src_docs/updatespecies.f90.md
+++ b/docs/src_docs/updatespecies.f90.md
@@ -1,0 +1,38 @@
+# updatespecies.f90
+
+## Overview
+
+*No overview extracted.*
+
+## Key Components
+
+- SUBROUTINE updatespecies
+
+## Important Variables/Constants
+
+- `character(100) :: buffer` (No comment)
+- `integer :: is, io, ist, lx, ilo, nlx, i` (No comment)
+- `type(xmlf_t), save :: xf` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- FoX_dom
+- FoX_wxml
+- modinput
+- modmain
+- modspdb
+- modspdeflist
+
+**Calls:**
+- xml_AddAttribute
+- xml_AddComment
+- xml_Close
+- xml_DeclareNamespace
+- xml_NewElement
+- xml_OpenFile
+- xml_endElement

--- a/docs/src_docs/vhalfinit.f90.md
+++ b/docs/src_docs/vhalfinit.f90.md
@@ -1,0 +1,70 @@
+# vhalfinit.f90
+
+## Overview
+
+  Initialises the crystal charge density. Inside the muffin-tins it is set to
+  the spherical atomic density. In the interstitial region it is taken to be
+  constant such that the total charge is correct. Requires that the atomic
+  densities have already been calculated.
+
+  Created January 2015 (Ronaldo R Pela)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE vhalfinit
+
+## Important Variables/Constants
+
+- `Complex (8), Allocatable :: zfft (:)` (No comment)
+- `Complex (8), Allocatable :: zfmt (:, :),z2fmt (:,:)` (No comment)
+- `Integer :: is, ia, ias, ig, ifg` (No comment)
+- `Integer :: lmax, lmmax, l, m, lm, ir, irc` (No comment)
+- `Integer, Parameter :: n = 4` (No comment)
+- `Real (8) :: fr (spnrmax), gr (spnrmax), cf (3, spnrmax)` (No comment)
+- `Real (8) :: rhoder,rhoder2, tp(2),r` (No comment)
+- `Real (8) :: ta,tb, tc,td` (No comment)
+- `Real (8) :: x, t1, t2, jlgr01, jlgr(0:1)` (No comment)
+- `Real (8), Allocatable :: auxgrid(:),auxrho(:),a(:),c(:),b(:)` (No comment)
+- `Real (8), Allocatable :: ffacg (:)` (No comment)
+- `Real (8), Allocatable :: jj(:,:)` (No comment)
+- `Real (8), Allocatable :: rhomodel(:,:)` (No comment)
+- `Real (8), Allocatable :: th (:, :)` (No comment)
+- `complex(8),allocatable :: swc2(:,:,:),swctmp(:,:,:)` (Comment: ,pwswc(:,:))
+- `integer :: auxgridsize,mtgridsize,lastpoint` (No comment)
+- `integer :: nsw,isw,jsw,info` (Comment:  number of spherical waves)
+- `integer, parameter :: PointsPerPeriod=20` (No comment)
+- `integer:: boundhi,boundlo,middle` (No comment)
+- `integer:: whichthread,nthreads` (No comment)
+- `real(8) :: aa,bb,ans,rmt3` (No comment)
+- `real(8) :: maxswg,swg,rhotest` (No comment)
+- `real(8), parameter :: sixth=1d0/6d0` (No comment)
+- `real(8), parameter :: third=1d0/3d0` (No comment)
+- `real(8), parameter :: threshold=1d-12` (No comment)
+- `real(8),allocatable :: swc(:),swoverlap(:,:),sine(:),cosine(:),swgr(:),pwswc(:,:),swoverlap2(:,:,:),pwswc2(:)` (No comment)
+- `real(8):: jthr,cs,sn,xi` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- constants
+- modinput
+- modmain
+- omp_lib
+
+**Calls:**
+- dgemv
+- dpotrf
+- dpotri
+- dpotrs
+- fderiv
+- rfmtctof
+- sbessel
+- timesec
+- zfftifc
+- ztorflm

--- a/docs/src_docs/writeeval.f90.md
+++ b/docs/src_docs/writeeval.f90.md
@@ -1,0 +1,37 @@
+# writeeval.f90
+
+## Overview
+
+  Outputs the second-variational eigenvalues and occupation numbers to the
+  file {\tt EIGVAL.OUT}.
+
+  Created June 2003 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE writeeval
+
+## Important Variables/Constants
+
+- `Integer :: ik, ist, is, ia, ias` (No comment)
+- `Type (xmlf_t), Save :: xf` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- Fox_wxml
+- modinput
+- modmain
+
+**Calls:**
+- xml_AddAttribute
+- xml_Close
+- xml_EndElement
+- xml_NewElement
+- xml_OpenFile

--- a/docs/src_docs/writefermi.f90.md
+++ b/docs/src_docs/writefermi.f90.md
@@ -1,0 +1,29 @@
+# writefermi.f90
+
+## Overview
+
+  Writes the Fermi energy to the file {\tt EFERMI.OUT}.
+
+  Created March 2005 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE writefermi
+
+## Important Variables/Constants
+
+*No important variables or constants identified.*
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modmain
+
+**Calls:**
+- *None identified.*

--- a/docs/src_docs/writestate.f90.md
+++ b/docs/src_docs/writestate.f90.md
@@ -1,0 +1,32 @@
+# writestate.f90
+
+## Overview
+
+  Writes the charge density, potentials and other relevant variables to the
+  file {\tt STATE.OUT}. Note to developers: changes to the way the variables
+  are written should be mirrored in {\tt readstate}.
+
+  Created May 2003 (JKD)
+EOP
+BOC
+
+## Key Components
+
+- SUBROUTINE writestate
+
+## Important Variables/Constants
+
+- `Integer :: is` (No comment)
+
+## Usage Examples
+
+*TODO: Add usage examples if applicable.*
+
+## Dependencies and Interactions
+
+**Uses:**
+- modinput
+- modmain
+
+**Calls:**
+- *None identified.*

--- a/generate_docs.py
+++ b/generate_docs.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Generates Markdown documentation from Fortran source files.
+"""
+import argparse
+import os
+import re
+import sys
+
+def parse_fortran_file(filepath):
+    """
+    Parses a Fortran file and extracts information for documentation.
+
+    Args:
+        filepath (str): Path to the Fortran source file.
+
+    Returns:
+        dict: A dictionary containing extracted information, or None if parsing fails.
+              Keys: 'overview', 'components', 'variables', 'dependencies', 'calls', 'filename'
+    """
+    if not os.path.exists(filepath):
+        print(f"Error: File not found: {filepath}", file=sys.stderr)
+        return None
+
+    filename = os.path.basename(filepath)
+    extracted_data = {
+        'overview': [],
+        'components': [],
+        'variables': [],
+        'dependencies': {'uses': [], 'calls': []},
+        'filename': filename
+    }
+
+    try:
+        with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+            lines = f.readlines()
+    except IOError as e:
+        print(f"Error reading file {filepath}: {e}", file=sys.stderr)
+        return None
+
+    in_description_block = False
+
+    for i, line_raw in enumerate(lines):
+        line = line_raw.strip()
+
+        # Overview
+        if re.match(r"!\s*!DESCRIPTION:", line, re.IGNORECASE):
+            in_description_block = True
+            # Capture text after "! !DESCRIPTION:" on the same line if any
+            match = re.match(r"!\s*!DESCRIPTION:(.*)", line, re.IGNORECASE)
+            if match and match.group(1).strip():
+                 extracted_data['overview'].append(match.group(1).strip())
+            continue
+
+        if in_description_block:
+            if line.startswith("!"):
+                # Remove the leading "!" and optional space
+                comment_text = re.sub(r"^!\s?", "", line)
+                if not comment_text.strip().startswith("!"): # Avoid lines like "!!" or "!!!" as start of content
+                    extracted_data['overview'].append(comment_text)
+                # If the line is just "!" or "!!", it might signify the end or a separator
+                elif not comment_text.strip():
+                    extracted_data['overview'].append("") # Keep empty lines for paragraph breaks
+            else:
+                # End of description block if a non-comment line is encountered
+                in_description_block = False
+
+        # Key Components
+        # MODULE
+        match = re.match(r"^\s*MODULE\s+([a-zA-Z_][a-zA-Z0-9_]*)", line, re.IGNORECASE)
+        if match:
+            extracted_data['components'].append(f"MODULE {match.group(1)}")
+            continue # Avoid double parsing if it's also a variable line
+
+        # SUBROUTINE
+        match = re.match(r"^\s*(?:RECURSIVE\s+)?SUBROUTINE\s+([a-zA-Z_][a-zA-Z0-9_]*)", line, re.IGNORECASE)
+        if match:
+            extracted_data['components'].append(f"SUBROUTINE {match.group(1)}")
+            continue
+
+        # FUNCTION
+        match = re.match(r"^\s*(?:RECURSIVE\s+)?(?:[a-zA-Z0-9_(),\s]+\s+)?FUNCTION\s+([a-zA-Z_][a-zA-Z0-9_]*)", line, re.IGNORECASE)
+        if match:
+            # Make sure it's not a type declaration like `TYPE(FUNCTION_POINTER) :: FP`
+            if not re.match(r"^\s*TYPE\s*\(", line, re.IGNORECASE):
+                 extracted_data['components'].append(f"FUNCTION {match.group(1)}")
+            continue
+
+        # Important Variables/Constants
+        # Basic types, TYPE(), and PARAMETER
+        # Covers: INTEGER :: var, REAL(8) :: var, TYPE(mytype) :: var, INTEGER, PARAMETER :: p = 1
+        var_match = re.match(
+            r"^\s*(TYPE\s*\(\s*[a-zA-Z_][a-zA-Z0-9_]*\s*\)"  # TYPE(custom_type)
+            r"|INTEGER(?:\s*\(.*?\))?"  # INTEGER or INTEGER(kind=...)
+            r"|REAL(?:\s*\(.*?\))?"     # REAL or REAL(kind=...)
+            r"|COMPLEX(?:\s*\(.*?\))?"  # COMPLEX or COMPLEX(kind=...)
+            r"|LOGICAL(?:\s*\(.*?\))?"  # LOGICAL or LOGICAL(kind=...)
+            r"|CHARACTER(?:\s*\(.*?\))?" # CHARACTER or CHARACTER(len=...)
+            r")"
+            r"(?:\s*,\s*(?:PARAMETER|ALLOCATABLE|DIMENSION\s*\(.*?\)|POINTER|TARGET|SAVE|INTENT\s*\(.*?\)))*" # Attributes
+            r"\s*::\s*([a-zA-Z_][a-zA-Z0-9_]*(?:\s*\(.*?\))?(?:\s*,\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\s*\(.*?\))?)*)" # Variable names list
+            r"(?:\s*=\s*.*?)?" # Optional initialization
+            r"(\s*!.*)?$", # Optional comment group 3
+            line, re.IGNORECASE
+        )
+        if var_match:
+            declaration_part = line.strip()
+            comment_part = ""
+            # Corrected group index from 4 to 3 for the comment
+            if var_match.group(3) and var_match.group(3).strip():
+                comment_part = var_match.group(3).strip()
+                # Remove comment from declaration part for cleaner output
+                declaration_part = line_raw[:line_raw.find(comment_part)].strip()
+
+            # If it's a parameter, format it slightly differently
+            if "parameter" in declaration_part.lower():
+                 extracted_data['variables'].append(f"`{declaration_part}` (Comment: {comment_part.lstrip('!') if comment_part else 'N/A'})")
+            else:
+                 extracted_data['variables'].append(f"`{declaration_part}` (Comment: {comment_part.lstrip('!') if comment_part else 'N/A'})")
+            continue
+
+
+        param_match = re.match(
+            r"^\s*(INTEGER|REAL|LOGICAL|CHARACTER(?:\s*\(.*?\))?)\s*,\s*PARAMETER\s*::\s*([a-zA-Z_][a-zA-Z0-9_]*(?:\s*=\s*.*?)?(?:\s*,\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\s*=\s*.*?)?)*)"
+            r"(\s*!.*)?$",
+            line, re.IGNORECASE
+        )
+        if param_match:
+            declaration_part = line.strip()
+            comment_part = ""
+            if param_match.group(3) and param_match.group(3).strip():
+                comment_part = param_match.group(3).strip()
+                declaration_part = line_raw[:line_raw.find(comment_part)].strip()
+
+            extracted_data['variables'].append(f"`{declaration_part}` (Comment: {comment_part.lstrip('!') if comment_part else 'N/A'})")
+            continue
+
+        # Dependencies and Interactions
+        # USE statements
+        use_match = re.match(r"^\s*USE\s+([a-zA-Z_][a-zA-Z0-9_]*)", line, re.IGNORECASE)
+        if use_match:
+            module_name = use_match.group(1)
+            if module_name.lower() != "intrinsic": # Exclude Fortran intrinsic modules if accidentally caught
+                if module_name not in extracted_data['dependencies']['uses']:
+                    extracted_data['dependencies']['uses'].append(module_name)
+            continue
+
+        # CALL statements
+        call_match = re.match(r"^\s*CALL\s+([a-zA-Z_][a-zA-Z0-9_]*)", line, re.IGNORECASE)
+        if call_match:
+            subroutine_name = call_match.group(1)
+            if subroutine_name not in extracted_data['dependencies']['calls']:
+                 extracted_data['dependencies']['calls'].append(subroutine_name)
+            continue
+
+    # Clean up overview: remove leading/trailing empty strings
+    while extracted_data['overview'] and not extracted_data['overview'][0]:
+        extracted_data['overview'].pop(0)
+    while extracted_data['overview'] and not extracted_data['overview'][-1]:
+        extracted_data['overview'].pop(-1)
+
+    return extracted_data
+
+def generate_markdown(data, output_dir):
+    """
+    Generates a Markdown file from the extracted Fortran data.
+
+    Args:
+        data (dict): Dictionary of data extracted by parse_fortran_file.
+        output_dir (str): Directory to save the Markdown file.
+    """
+    if not data:
+        return
+
+    md_filename = data['filename'] + ".md"
+    md_filepath = os.path.join(output_dir, md_filename)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    with open(md_filepath, 'w', encoding='utf-8') as f:
+        f.write(f"# {data['filename']}\n\n")
+
+        f.write("## Overview\n\n")
+        if data['overview']:
+            for line in data['overview']:
+                f.write(f"{line}\n")
+            f.write("\n")
+        else:
+            f.write("*No overview extracted.*\n\n")
+
+        f.write("## Key Components\n\n")
+        if data['components']:
+            for comp in sorted(list(set(data['components']))): # Sort and unique
+                f.write(f"- {comp}\n")
+            f.write("\n")
+        else:
+            f.write("*No key components (modules, subroutines, functions) identified.*\n\n")
+
+        f.write("## Important Variables/Constants\n\n")
+        if data['variables']:
+            for var in sorted(list(set(data['variables']))): # Sort and unique
+                 # Ensure comments are handled cleanly
+                if "(Comment: )" in var:
+                    var = var.replace("(Comment: )", "(No comment)")
+                elif "(Comment: N/A)" in var:
+                    var = var.replace("(Comment: N/A)", "(No comment)")
+                f.write(f"- {var}\n")
+            f.write("\n")
+        else:
+            f.write("*No important variables or constants identified.*\n\n")
+
+        f.write("## Usage Examples\n\n")
+        f.write("*TODO: Add usage examples if applicable.*\n\n")
+        # Stretch goal: Attempt to find calls to public routines defined in this file
+        # This is a simplified heuristic
+        # own_routines = [name.split()[-1] for name in data['components'] if name.startswith("SUBROUTINE") or name.startswith("FUNCTION")]
+        # if own_routines and data['dependencies']['calls']:
+        #     simple_examples = []
+        #     for called_routine in data['dependencies']['calls']:
+        #         if called_routine in own_routines:
+        #             # This is very basic, would need full line for context
+        #             simple_examples.append(f"CALL {called_routine}(...)")
+        #     if simple_examples:
+        #         f.write("**Potential internal calls (heuristic):**\n")
+        #         for ex in sorted(list(set(simple_examples))):
+        #             f.write(f"- `{ex}`\n")
+        #         f.write("\n")
+
+
+        f.write("## Dependencies and Interactions\n\n")
+        f.write("**Uses:**\n")
+        if data['dependencies']['uses']:
+            for use in sorted(list(set(data['dependencies']['uses']))):
+                f.write(f"- {use}\n")
+        else:
+            f.write("- *None identified.*\n")
+        f.write("\n")
+
+        f.write("**Calls:**\n")
+        if data['dependencies']['calls']:
+            for call in sorted(list(set(data['dependencies']['calls']))):
+                f.write(f"- {call}\n")
+        else:
+            f.write("- *None identified.*\n")
+        f.write("\n")
+
+    print(f"Successfully generated Markdown: {md_filepath}")
+
+
+def main():
+    """Main function to handle argument parsing and script execution."""
+    parser = argparse.ArgumentParser(description="Generate Markdown documentation from a Fortran source file.")
+    parser.add_argument("fortran_file", help="Path to the Fortran source file (.f90, .F90, .f)")
+
+    args = parser.parse_args()
+
+    fortran_filepath = args.fortran_file
+    output_directory = "docs/src_docs"
+
+    if not os.path.exists(fortran_filepath):
+        print(f"Error: Input Fortran file not found: {fortran_filepath}", file=sys.stderr)
+        sys.exit(1)
+
+    if not (fortran_filepath.endswith(".f90") or \
+            fortran_filepath.endswith(".F90") or \
+            fortran_filepath.endswith(".f")):
+        print(f"Warning: Input file '{fortran_filepath}' does not have a typical Fortran extension (.f90, .F90, .f).", file=sys.stderr)
+
+    # Ensure output directory exists
+    try:
+        os.makedirs(output_directory, exist_ok=True)
+    except OSError as e:
+        print(f"Error: Could not create output directory {output_directory}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    parsed_data = parse_fortran_file(fortran_filepath)
+
+    if parsed_data:
+        generate_markdown(parsed_data, output_directory)
+    else:
+        print(f"Could not parse Fortran file: {fortran_filepath}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/markdown_template.py
+++ b/markdown_template.py
@@ -1,0 +1,30 @@
+MARKDOWN_TEMPLATE = """# {filename}
+
+## Overview
+
+(Placeholder for a brief description of the code file)
+
+## Key Components
+
+(Placeholder for a list of primary functions, classes, or modules)
+
+## Important Variables/Constants
+
+(Placeholder for descriptions of critical variables or constants)
+
+## Usage Examples
+
+```fortran
+(Placeholder for code snippets or examples)
+```
+
+## Dependencies and Interactions
+
+(Placeholder for notes on dependencies and interactions with other parts of the code, or external libraries)
+"""
+
+if __name__ == '__main__':
+    # This part is just for testing the template string.
+    # It won't be executed by the agent but can be run locally.
+    print("Markdown Template String:")
+    print(MARKDOWN_TEMPLATE.format(filename="example_file.f90"))


### PR DESCRIPTION
Adds Markdown documentation for 69 Fortran files in the src/ directory. I generated these files using a Python script that parses the source code to extract overviews, key components, variables, and dependencies.

The generate_docs.py script is also included.

This is a baseline generation, and the documentation, particularly the "Important Variables/Constants" and "Usage Examples" sections, will require further manual review and refinement. Many source files were not processed due to unavailability in the execution environment.